### PR TITLE
Changes for pkgdown and auto build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^LICENSE\.md$
 ^textrecipes\.Rproj$
 ^\.Rproj\.user$
+^docs$
+^_pkgdown\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ inst/doc
 .Rhistory
 .RData
 .Ruserdata
+docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,26 @@ env:
   global:
   - MAKEFLAGS="-j 2"
   
-r:
-- 3.1
-- 3.2
-- oldrel
-- release
-- devel
-
+r_github_packages:
+  - r-lib/pkgdown
+  - tidyverse/tidytemplate
+  
 matrix:
+  include:
+  - r: devel
+  - r: release
+    after_success:
+    - Rscript -e 'covr::codecov()'
+
+    deploy:
+      provider: script
+      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+      skip-cleanup: true
+  - r: oldrel
+  - r: 3.2
+  - r: 3.1
   allow_failures:
-    - r: 3.1
-    - r: 3.2
-
+  - r: 3.2
+  - r: 3.1
+  
 warnings_are_errors: false
-
-after_success:
-  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,5 @@ Imports:
     stringr,
     text2vec
 Remotes:
-    tidymodels/recipes,
-    r-lib/generics
+    tidymodels/recipes
 VignetteBuilder: knitr

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,6 +20,8 @@ knitr::opts_chunk$set(
 [![Downloads](http://cranlogs.r-pkg.org/badges/textrecipes)](http://cran.rstudio.com/package=textrecipes)
 [![lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 
+## Introduction
+
 **textrecipes** contains extra steps for the [`recipes`](http://cran.rstudio.com/package=recipes) package for preprocessing text data. 
 
 ## Installation
@@ -28,7 +30,7 @@ textrecipes is not avaliable from [CRAN](https://CRAN.R-project.org) yet. But th
 
 ```{r installation, eval=FALSE}
 require("devtools")
-install_github("emilhvitfeldt/textrecipes")
+install_github("tidymodels/textrecipes")
 ```
 
 ## Example

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,11 @@
+template:
+  package: tidytemplate
+  params:
+    part_of: <a href="https://github.com/tidymodels">tidymodels</a>
+    footer: textrecipes is a part of the <strong>tidymodels</strong> ecosystem, a collection of modeling packages designed with common APIs and a shared philosophy.
+
+development:
+  mode: auto
+
+home:
+  strip_header: true


### PR DESCRIPTION
This should get auto-pkgdown going as soon as it is merged into master. It should update the `gh-pages` branch with the built pkgdown site from the `release` build on Travis. There are still a few pkgdown issues being worked out regarding some corner cases, but they will be folded in automatically once resolved b/c it downloads pkgdown from github every time.