### PR TITLE
don't wnd with as_tibble() in bake functions

### DIFF
--- a/R/clean_levels.R
+++ b/R/clean_levels.R
@@ -126,7 +126,7 @@ bake.step_clean_levels <- function(object, new_data, ...) {
     }
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -107,7 +107,7 @@ bake.step_clean_names <- function(object, new_data, ...) {
     colnames(new_data) <- dplyr::recode(colnames(new_data), !!!object$clean)
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 

--- a/R/embeddings.R
+++ b/R/embeddings.R
@@ -232,7 +232,7 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
     }
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/hashing.R
+++ b/R/hashing.R
@@ -167,7 +167,7 @@ bake.step_texthash <- function(object, new_data, ...) {
     new_data <- vctrs::vec_cbind(tf_text, new_data)
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/hashing_dummy.R
+++ b/R/hashing_dummy.R
@@ -199,7 +199,7 @@ bake.step_dummy_hash <- function(object, new_data, ...) {
     new_data <- new_data[, !(colnames(new_data) %in% col_names), drop = FALSE]
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/lda.R
+++ b/R/lda.R
@@ -182,7 +182,7 @@ bake.step_lda <- function(object, new_data, ...) {
     }
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/lemma.R
+++ b/R/lemma.R
@@ -121,7 +121,7 @@ bake.step_lemma <- function(object, new_data, ...) {
     new_data[, col_names[i]] <- tibble(lemma_variable)
   }
   new_data <- factor_to_text(new_data, col_names)
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/ngram.R
+++ b/R/ngram.R
@@ -137,7 +137,7 @@ bake.step_ngram <- function(object, new_data, ...) {
     new_data[, col_names[i]] <- tibble(ngrammed_tokenlist)
   }
   new_data <- factor_to_text(new_data, col_names)
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/pos_filter.R
+++ b/R/pos_filter.R
@@ -128,7 +128,7 @@ bake.step_pos_filter <- function(object, new_data, ...) {
     new_data[, col_names[i]] <- tibble(pos_filter_variable)
   }
   new_data <- factor_to_text(new_data, col_names)
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/sequence_onehot.R
+++ b/R/sequence_onehot.R
@@ -181,7 +181,7 @@ bake.step_sequence_onehot <- function(object, new_data, ...) {
 
     new_data <- vctrs::vec_cbind(new_data, as_tibble(out_text))
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/stem.R
+++ b/R/stem.R
@@ -150,7 +150,7 @@ bake.step_stem <- function(object, new_data, ...) {
     new_data[, col_names[i]] <- tibble(stemmed_tokenlist)
   }
   new_data <- factor_to_text(new_data, col_names)
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/stopwords.R
+++ b/R/stopwords.R
@@ -165,7 +165,7 @@ bake.step_stopwords <- function(object, new_data, ...) {
   }
   new_data <- factor_to_text(new_data, col_names)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/text_normalization.R
+++ b/R/text_normalization.R
@@ -137,7 +137,7 @@ bake.step_text_normalization <- function(object, new_data, ...) {
     )
   }
   new_data <- factor_to_text(new_data, col_names)
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/textfeature.R
+++ b/R/textfeature.R
@@ -163,7 +163,7 @@ bake.step_textfeature <- function(object, new_data, ...) {
         new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
     }
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tf.R
+++ b/R/tf.R
@@ -199,7 +199,7 @@ bake.step_tf <- function(object, new_data, ...) {
     
     new_data <- vctrs::vec_cbind(new_data, tf_text)
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tfidf.R
+++ b/R/tfidf.R
@@ -191,7 +191,7 @@ bake.step_tfidf <- function(object, new_data, ...) {
 
     new_data <- vctrs::vec_cbind(new_data, tfidf_text)
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -191,7 +191,7 @@ bake.step_tokenfilter <- function(object, new_data, ...) {
   }
   new_data <- factor_to_text(new_data, col_names)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -316,7 +316,7 @@ bake.step_tokenize <- function(object, new_data, ...) {
       token = object$custom_token[[i]]
     )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenize_bpe.R
+++ b/R/tokenize_bpe.R
@@ -167,7 +167,7 @@ bake.step_tokenize_bpe <- function(object, new_data, ...) {
     )
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenize_sentencepiece.R
+++ b/R/tokenize_sentencepiece.R
@@ -172,7 +172,7 @@ bake.step_tokenize_sentencepiece <- function(object, new_data, ...) {
     )
   }
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenize_wordpiece.R
+++ b/R/tokenize_wordpiece.R
@@ -139,7 +139,7 @@ bake.step_tokenize_wordpiece <- function(object, new_data, ...) {
     )
   }
   
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/tokenmerge.R
+++ b/R/tokenmerge.R
@@ -118,7 +118,7 @@ bake.step_tokenmerge <- function(object, new_data, ...) {
 
   new_data <- vctrs::vec_cbind(new_data, new_col)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/untokenize.R
+++ b/R/untokenize.R
@@ -122,7 +122,7 @@ bake.step_untokenize <- function(object, new_data, ...) {
 
   new_data <- factor_to_text(new_data, col_names)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export


### PR DESCRIPTION
Since `bake.recipe()` calls `as_tibble()` after each step we don't need to do it inside each step.