### PR TITLE
Unname before handing off to `c_across()`

### DIFF
--- a/R/hashing_dummy.R
+++ b/R/hashing_dummy.R
@@ -161,6 +161,7 @@ bake.step_dummy_hash <- function(object, new_data, ...) {
 
   col_names <- object$columns
   hash_cols <- col_names
+  hash_cols <- unname(hash_cols)
   
   check_new_data(col_names, object, new_data)
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`c_across()` now asserts that the tidyselection vector can't be named, because this implies you are trying to rename and that doesn't make any sense in that function.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!