### PR TITLE
Clean up loops

### DIFF
--- a/R/clean_levels.R
+++ b/R/clean_levels.R
@@ -116,16 +116,18 @@ prep.step_clean_levels <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_clean_levels <- function(object, new_data, ...) {
-  if (length(object$clean) == 0L) {
-    # Empty selection
-    return(new_data)
-  }
+  col_names <- names(object$clean)
   check_new_data(names(object$clean), object, new_data)
 
-  if (!is.null(object$clean)) {
-    for (i in names(object$clean)) {
-      new_data[[i]] <- dplyr::recode_factor(new_data[[i]], !!!object$clean[[i]])
-    }
+  if (is.null(names(object$clean))) {
+    # Backwards compatibility with 1.0.3 (#230)
+    names(object$clean) <- col_names
+  }
+  
+  for (col_name in col_names) {
+    new_data[[col_name]] <- dplyr::recode_factor(
+      new_data[[col_name]], !!!object$clean[[col_name]]
+    )
   }
 
   new_data

--- a/R/dummy_hash.R
+++ b/R/dummy_hash.R
@@ -183,13 +183,13 @@ bake.step_dummy_hash <- function(object, new_data, ...) {
     hash_cols <- new_name
   }
 
-  for (i in seq_along(hash_cols)) {
+  for (hash_col in hash_cols) {
     tf_text <-
       hashing_function(
-        as.character(new_data[[hash_cols[i]]]),
+        as.character(new_data[[hash_col]]),
         paste0(
           object$prefix, "_",
-          hash_cols[i], "_",
+          hash_col, "_",
           names0(object$num_terms, "")
         ),
         object$signed,
@@ -200,7 +200,7 @@ bake.step_dummy_hash <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% hash_cols[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% hash_col), drop = FALSE]
     }
 
     tf_text <- check_name(tf_text, new_data, object, names(tf_text))

--- a/R/lemma.R
+++ b/R/lemma.R
@@ -106,13 +106,13 @@ bake.step_lemma <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    variable <- new_data[[col_names[i]]]
+  for (col_name in col_names) {
+    variable <- new_data[[col_name]]
 
     if (is.null(maybe_get_lemma(variable))) {
       rlang::abort(
         glue(
-          "`{col_names[i]}` doesn't have a lemma attribute. ",
+          "`{col_name}` doesn't have a lemma attribute. ",
           "Make sure the tokenization step includes lemmatization."
         )
       )
@@ -120,7 +120,7 @@ bake.step_lemma <- function(object, new_data, ...) {
       lemma_variable <- tokenlist_lemma(variable)
     }
 
-    new_data[[col_names[i]]] <- tibble(lemma_variable)
+    new_data[[col_name]] <- tibble(lemma_variable)
   }
   new_data <- factor_to_text(new_data, col_names)
   new_data

--- a/R/ngram.R
+++ b/R/ngram.R
@@ -134,15 +134,15 @@ bake.step_ngram <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
+  for (col_name in col_names) {
     ngrammed_tokenlist <- tokenlist_ngram(
-      x = new_data[[col_names[i]]],
+      x = new_data[[col_name]],
       n = object$num_tokens,
       n_min = object$min_num_tokens,
       delim = object$delim
     )
 
-    new_data[, col_names[i]] <- tibble(ngrammed_tokenlist)
+    new_data[[col_name]] <- ngrammed_tokenlist
   }
   new_data <- factor_to_text(new_data, col_names)
   new_data

--- a/R/pos_filter.R
+++ b/R/pos_filter.R
@@ -112,20 +112,20 @@ bake.step_pos_filter <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    variable <- new_data[[col_names[i]]]
+  for (col_name in col_names) {
+    variable <- new_data[[col_name]]
 
     if (is.null(maybe_get_pos(variable))) {
       rlang::abort(
         glue(
-          "`{col_names[i]}` doesn't have a pos attribute. ",
+          "`{col_name}` doesn't have a pos attribute. ",
           "Make sure the tokenization step includes ",
           "part of speech tagging."
         )
       )
     }
 
-    new_data[[col_names[i]]] <- tokenlist_pos_filter(variable, object$keep_tags)
+    new_data[[col_name]] <- tokenlist_pos_filter(variable, object$keep_tags)
   }
   new_data <- factor_to_text(new_data, col_names)
   new_data

--- a/R/sequence_onehot.R
+++ b/R/sequence_onehot.R
@@ -133,9 +133,9 @@ prep.step_sequence_onehot <- function(x, training, info = NULL, ...) {
 
   token_list <- list()
 
-  for (i in seq_along(col_names)) {
-    token_list[[i]] <- x$vocabulary %||%
-      sort(get_unique_tokens(training[, col_names[i], drop = TRUE]))
+  for (col_name in col_names) {
+    token_list[[col_name]] <- x$vocabulary %||%
+      sort(get_unique_tokens(training[[col_name]]))
   }
 
   step_sequence_onehot_new(
@@ -158,11 +158,16 @@ prep.step_sequence_onehot <- function(x, training, info = NULL, ...) {
 bake.step_sequence_onehot <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
+  
+  if (is.null(names(object$vocabulary))) {
+    # Backwards compatibility with 1.0.3 (#230)
+    names(object$vocabulary) <- col_names
+  }
 
-  for (i in seq_along(col_names)) {
+  for (col_name in col_names) {
     out_text <- string2encoded_matrix(
-      x = new_data[[col_names[i]]],
-      vocabulary = object$vocabulary[[i]],
+      x = new_data[[col_name]],
+      vocabulary = object$vocabulary[[col_name]],
       sequence_length = object$sequence_length,
       padding = object$padding,
       truncating = object$truncating
@@ -171,7 +176,7 @@ bake.step_sequence_onehot <- function(object, new_data, ...) {
     colnames(out_text) <- paste(
       sep = "_",
       object$prefix,
-      col_names[i],
+      col_name,
       seq_len(ncol(out_text))
     )
     
@@ -180,7 +185,7 @@ bake.step_sequence_onehot <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% col_name), drop = FALSE]
     }
     
     out_text <- check_name(out_text, new_data, object, names(out_text))

--- a/R/stem.R
+++ b/R/stem.R
@@ -143,9 +143,9 @@ bake.step_stem <- function(object, new_data, ...) {
   stem_fun <- object$custom_stemmer %||%
     SnowballC::wordStem
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- tokenlist_apply(
-      new_data[[col_names[i]]],
+  for (col_name in col_names) {
+    new_data[[col_name]] <- tokenlist_apply(
+      new_data[[col_name]],
       stem_fun, object$options
     )
   }

--- a/R/stopwords.R
+++ b/R/stopwords.R
@@ -154,9 +154,9 @@ bake.step_stopwords <- function(object, new_data, ...) {
       source = object$stopword_source
     )
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- tokenlist_filter(
-      new_data[[col_names[i]]],
+  for (col_name in col_names) {
+    new_data[[col_name]] <- tokenlist_filter(
+      new_data[[col_name]],
       stopword_list,
       object$keep
     )

--- a/R/text_normalization.R
+++ b/R/text_normalization.R
@@ -131,9 +131,10 @@ bake.step_text_normalization <- function(object, new_data, ...) {
     )
   )
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- normalization_fun(new_data[[col_names[i]]])
+  for (col_name in col_names) {
+    new_data[[col_name]] <- normalization_fun(new_data[[col_name]])
   }
+  
   new_data <- factor_to_text(new_data, col_names)
   new_data
 }

--- a/R/textfeature.R
+++ b/R/textfeature.R
@@ -145,13 +145,13 @@ bake.step_textfeature <- function(object, new_data, ...) {
 
   new_data <- factor_to_text(new_data, col_names)
 
-  for (i in seq_along(col_names)) {
-    tf_text <- map_dfc(
-      object$extract_functions,
-      ~ .x(new_data[[col_names[i]]])
-    )
+  for (col_name in col_names) {
+    tf_text <- map_dfc(object$extract_functions, ~ .x(new_data[[col_name]]))
 
-    colnames(tf_text) <- paste(object$prefix, col_names[i], colnames(tf_text),
+    colnames(tf_text) <- paste(
+      object$prefix,
+      col_name, 
+      colnames(tf_text),
       sep = "_"
     )
 
@@ -162,7 +162,7 @@ bake.step_textfeature <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% col_name), drop = FALSE]
     }
   }
   new_data

--- a/R/texthash.R
+++ b/R/texthash.R
@@ -152,12 +152,12 @@ bake.step_texthash <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
+  for (col_name in col_names) {
     tf_text <- hashing_function(
-      get_tokens(new_data[[col_names[i]]]),
+      get_tokens(new_data[[col_name]]),
       paste0(
         object$prefix, "_",
-        col_names[i], "_",
+        col_name, "_",
         names0(object$num_terms, "")
       ),
       object$signed,
@@ -168,7 +168,7 @@ bake.step_texthash <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% col_name), drop = FALSE]
     }
     
     tf_text <- check_name(tf_text, new_data, object, names(tf_text))

--- a/R/tf.R
+++ b/R/tf.R
@@ -154,9 +154,9 @@ prep.step_tf <- function(x, training, info = NULL, ...) {
 
   token_list <- list()
 
-  for (i in seq_along(col_names)) {
-    token_list[[i]] <- x$vocabulary %||%
-      sort(get_unique_tokens(training[, col_names[i], drop = TRUE]))
+  for (col_name in col_names) {
+    token_list[[col_name]] <- x$vocabulary %||%
+      sort(get_unique_tokens(training[[col_name]]))
   }
 
   step_tf_new(
@@ -180,11 +180,16 @@ bake.step_tf <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
+  if (is.null(names(object$res))) {
+    # Backwards compatibility with 1.0.3
+    names(object$res) <- col_names
+  }
+  
+  for (col_name in col_names) {
     tf_text <- tf_function(
-      new_data[[col_names[i]]],
-      object$res[[i]],
-      paste0(object$prefix, "_", col_names[i]),
+      new_data[[col_name]],
+      object$res[[col_name]],
+      paste0(object$prefix, "_", col_name),
       object$weight_scheme,
       object$weight
     )
@@ -196,7 +201,7 @@ bake.step_tf <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% col_name), drop = FALSE]
     }
     
     tf_text <- check_name(tf_text, new_data, object, names(tf_text))

--- a/R/tf.R
+++ b/R/tf.R
@@ -181,7 +181,7 @@ bake.step_tf <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
 
   if (is.null(names(object$res))) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$res) <- col_names
   }
   

--- a/R/tfidf.R
+++ b/R/tfidf.R
@@ -176,7 +176,7 @@ bake.step_tfidf <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
 
   if (is.null(names(object$res))) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$res) <- col_names
   }
   

--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -184,7 +184,7 @@ bake.step_tokenfilter <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
 
   if (is.null(names(object$res)) && is.null(object$filter_fun)) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$res) <- col_names
   }
   

--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -150,13 +150,13 @@ prep.step_tokenfilter <- function(x, training, info = NULL, ...) {
   n_words <- integer()
 
   if (is.null(x$filter_fun)) {
-    for (i in seq_along(col_names)) {
-      retain_words[[i]] <- tokenfilter_fun(
-        training[[col_names[i]]],
+    for (col_name in col_names) {
+      retain_words[[col_name]] <- tokenfilter_fun(
+        training[[col_name]],
         x$max_times, x$min_times, x$max_tokens,
         x$percentage
       )
-      n_words[[i]] <- length(unique(unlist(training[[col_names[i]]])))
+      n_words[[col_name]] <- length(unique(unlist(training[[col_name]])))
     }
   }
 
@@ -181,21 +181,21 @@ bake.step_tokenfilter <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
+  for (col_name in col_names) {
     if (is.null(object$filter_fun)) {
       filtered_text <- tokenlist_filter(
-        new_data[[col_names[i]]],
-        object$res[[i]],
+        new_data[[col_name]],
+        object$res[[col_name]],
         TRUE
       )
     } else {
       filtered_text <- tokenlist_filter_function(
-        new_data[[col_names[i]]],
+        new_data[[col_name]],
         object$filter_fun
       )
     }
 
-    new_data[[col_names[i]]] <- filtered_text
+    new_data[[col_name]] <- filtered_text
   }
   new_data <- factor_to_text(new_data, col_names)
 

--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -158,6 +158,8 @@ prep.step_tokenfilter <- function(x, training, info = NULL, ...) {
       )
       n_words[[col_name]] <- length(unique(unlist(training[[col_name]])))
     }
+  } else {
+    
   }
 
   step_tokenfilter_new(
@@ -181,6 +183,11 @@ bake.step_tokenfilter <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
+  if (is.null(names(object$res)) && is.null(object$filter_fun)) {
+    # Backwards compatibility with 1.0.3
+    names(object$res) <- col_names
+  }
+  
   for (col_name in col_names) {
     if (is.null(object$filter_fun)) {
       filtered_text <- tokenlist_filter(

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -316,6 +316,11 @@ bake.step_tokenize <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
+  if (is.null(names(object$res))) {
+    # Backwards compatibility with 1.0.3
+    names(object$custom_token) <- col_names
+  }
+  
   for (col_name in col_names) {
     new_data[[col_name]] <- tokenizer_fun(
       x = new_data[[col_name]],

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -316,7 +316,7 @@ bake.step_tokenize <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  if (is.null(names(object$res))) {
+  if (is.null(names(object$custom_token))) {
     # Backwards compatibility with 1.0.3 (#230)
     names(object$custom_token) <- col_names
   }

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -285,14 +285,15 @@ prep.step_tokenize <- function(x, training, info = NULL, ...) {
 
   tokenizers <- list()
 
-  for (i in seq_along(col_names)) {
-    text <- training[[col_names[[i]]]]
+  for (col_name in col_names) {
+    text <- training[[col_name]]
 
     if (x$engine == "tokenizers.bpe" & !is.null(x$training_options$vocab_size)) {
-      check_bpe_vocab_size(text, x$training_options$vocab_size, col_names[[i]])
+      check_bpe_vocab_size(text, x$training_options$vocab_size, col_name)
     }
 
-    tokenizers[[i]] <- x$custom_token %||% tokenizer_switch(x$token, x, text)
+    tokenizers[[col_name]] <- x$custom_token %||% 
+      tokenizer_switch(x$token, x, text)
   }
 
   step_tokenize_new(
@@ -315,11 +316,11 @@ bake.step_tokenize <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- tokenizer_fun(
-      x = new_data[[col_names[i]]],
+  for (col_name in col_names) {
+    new_data[[col_name]] <- tokenizer_fun(
+      x = new_data[[col_name]],
       options = object$options,
-      token = object$custom_token[[i]]
+      token = object$custom_token[[col_name]]
     )
   }
   new_data

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -317,7 +317,7 @@ bake.step_tokenize <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
 
   if (is.null(names(object$res))) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$custom_token) <- col_names
   }
   

--- a/R/tokenize_bpe.R
+++ b/R/tokenize_bpe.R
@@ -116,12 +116,12 @@ prep.step_tokenize_bpe <- function(x, training, info = NULL, ...) {
   }
   bpe_options$vocab_size <- x$vocabulary_size
 
-  for (i in seq_along(col_names)) {
-    text <- training[, col_names[[i]], drop = TRUE]
+  for (col_name in col_names) {
+    text <- training[[col_name]]
 
-    check_bpe_vocab_size(text, x$vocabulary_size, col_names[[i]])
+    check_bpe_vocab_size(text, x$vocabulary_size, col_name)
 
-    tokenizers[[i]] <- tokenizers_bpe_tokens(text, bpe_options)
+    tokenizers[[col_name]] <- tokenizers_bpe_tokens(text, bpe_options)
   }
 
   step_tokenize_bpe_new(

--- a/R/tokenize_bpe.R
+++ b/R/tokenize_bpe.R
@@ -162,6 +162,11 @@ bake.step_tokenize_bpe <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
+  if (is.null(names(object$res))) {
+    # Backwards compatibility with 1.0.3
+    names(object$res) <- col_names
+  }
+  
   for (i in seq_along(col_names)) {
     new_data[[col_names[i]]] <- tokenizer_fun(
       x = new_data[[col_names[i]]],

--- a/R/tokenize_bpe.R
+++ b/R/tokenize_bpe.R
@@ -163,7 +163,7 @@ bake.step_tokenize_bpe <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
 
   if (is.null(names(object$res))) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$res) <- col_names
   }
   

--- a/R/tokenize_sentencepiece.R
+++ b/R/tokenize_sentencepiece.R
@@ -121,12 +121,15 @@ prep.step_tokenize_sentencepiece <- function(x, training, info = NULL, ...) {
   }
   sentencepiece_options$vocab_size <- x$vocabulary_size
 
-  for (i in seq_along(col_names)) {
-    text <- training[[col_names[[i]]]]
+  for (col_name in col_names) {
+    text <- training[[col_name]]
 
-    check_sentencepiece_vocab_size(text, x$vocabulary_size, col_names[[i]])
+    check_sentencepiece_vocab_size(text, x$vocabulary_size, col_name)
 
-    tokenizers[[i]] <- tokenizers_sentencepiece_tokens(text, sentencepiece_options)
+    tokenizers[[col_name]] <- tokenizers_sentencepiece_tokens(
+      text,
+      sentencepiece_options
+    )
   }
 
   step_tokenize_sentencepiece_new(
@@ -167,11 +170,11 @@ bake.step_tokenize_sentencepiece <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- tokenizer_fun(
-      x = new_data[[col_names[i]]],
+  for (col_name in col_names) {
+    new_data[[col_name]] <- tokenizer_fun(
+      x = new_data[[col_name]],
       options = object$options,
-      token = object$res[[i]]
+      token = object$res[[col_name]]
     )
   }
 

--- a/R/tokenize_sentencepiece.R
+++ b/R/tokenize_sentencepiece.R
@@ -169,7 +169,12 @@ check_sentencepiece_vocab_size <- function(text,
 bake.step_tokenize_sentencepiece <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
-
+  
+  if (is.null(names(object$res))) {
+    # Backwards compatibility with 1.0.3
+    names(object$res) <- col_names
+  }
+  
   for (col_name in col_names) {
     new_data[[col_name]] <- tokenizer_fun(
       x = new_data[[col_name]],

--- a/R/tokenize_sentencepiece.R
+++ b/R/tokenize_sentencepiece.R
@@ -171,7 +171,7 @@ bake.step_tokenize_sentencepiece <- function(object, new_data, ...) {
   check_new_data(col_names, object, new_data)
   
   if (is.null(names(object$res))) {
-    # Backwards compatibility with 1.0.3
+    # Backwards compatibility with 1.0.3 (#230)
     names(object$res) <- col_names
   }
   

--- a/R/tokenize_wordpiece.R
+++ b/R/tokenize_wordpiece.R
@@ -123,9 +123,9 @@ bake.step_tokenize_wordpiece <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    new_data[[col_names[i]]] <- tokenizer_fun(
-      x = new_data[[col_names[i]]],
+  for (col_name in col_names) {
+    new_data[[col_name]] <- tokenizer_fun(
+      x = new_data[[col_name]],
       options = list(
         vocab = object$vocab,
         unk_token = object$unk_token,

--- a/R/untokenize.R
+++ b/R/untokenize.R
@@ -113,17 +113,12 @@ bake.step_untokenize <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  for (i in seq_along(col_names)) {
-    tokens <- get_tokens(new_data[[col_names[i]]])
-    new_data[[col_names[i]]] <- map_chr(
-      .x = tokens,
-      .f = paste,
-      collapse = object$sep
-    )
+  for (col_name in col_names) {
+    tokens <- get_tokens(new_data[[col_name]])
+    new_data[[col_name]] <- map_chr(tokens, paste, collapse = object$sep)
   }
 
   new_data <- factor_to_text(new_data, col_names)
-
   new_data
 }
 

--- a/R/word_embeddings.R
+++ b/R/word_embeddings.R
@@ -176,27 +176,21 @@ prep.step_word_embeddings <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_word_embeddings <- function(object, new_data, ...) {
-  if (length(object$column) == 0L) {
-    # Empty selection
-    return(new_data)
-  }
-
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
   aggregation_fun <- get_aggregation_fun(object)
   
-  for (i in seq_along(col_names)) {
-
+  for (col_name in col_names) {
     emb_columns <- tokenlist_embedding(
-      new_data[[col_names[i]]],
+      new_data[[col_name]],
       object$embeddings,
       aggregation_fun
     )
 
     colnames(emb_columns) <- paste(
       object$prefix,
-      col_names[i],
+      col_name,
       colnames(emb_columns),
       sep = "_"
     )
@@ -208,7 +202,7 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
     keep_original_cols <- get_keep_original_cols(object)
     if (!keep_original_cols) {
       new_data <-
-        new_data[, !(colnames(new_data) %in% col_names[i]), drop = FALSE]
+        new_data[, !(colnames(new_data) %in% col_name), drop = FALSE]
     }
   }
 

--- a/R/word_embeddings.R
+++ b/R/word_embeddings.R
@@ -184,33 +184,9 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
+  aggregation_fun <- get_aggregation_fun(object)
+  
   for (i in seq_along(col_names)) {
-    aggregation_fun <- switch(object$aggregation,
-      sum = function(x, ...) {
-        if (length(x) == 0) {
-          return(object$aggregation_default)
-        }
-        sum(x, ...)
-      },
-      mean = function(x, ...) {
-        if (length(x) == 0) {
-          return(object$aggregation_default)
-        }
-        mean(x, ...)
-      },
-      min = function(x, ...) {
-        if (length(x) == 0) {
-          return(object$aggregation_default)
-        }
-        min(x, ...)
-      },
-      max = function(x, ...) {
-        if (length(x) == 0) {
-          return(object$aggregation_default)
-        }
-        max(x, ...)
-      }
-    )
 
     emb_columns <- tokenlist_embedding(
       new_data[[col_names[i]]],
@@ -237,6 +213,23 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
   }
 
   new_data
+}
+
+get_aggregation_fun <- function(object) {
+  fun <- switch(
+    EXPR = object$aggregation,
+    sum = sum,
+    mean = mean,
+    min = min,
+    max = max
+  )
+  
+  function(x, ...) {
+    if (length(x) == 0) {
+      return(object$aggregation_default)
+    }
+    fun(x, ...)
+  }
 }
 
 #' @export


### PR DESCRIPTION
Many of these steps operate on a loop basis. This PR makes changes such that they all following this structure

```r
for (col_name in col_names) {
  do something with  new_data[[col_name]]
}
```

In the steps where the `prep()` method was changes to this format, a condition is added to the corresponding `bake()` method to preserve backwards compatibility

```r
  if (is.null(names(object$res))) {
    # Backwards compatibility with 1.0.3 (#230)
    names(object$res) <- col_names
  }
```

It will also be technically faster in some situations where `col_names[i]` were called multiple times