### PR TITLE
move extract_parameter_set_dials to infrastructure section

### DIFF
--- a/tests/testthat/test-dummy_hash.R
+++ b/tests/testthat/test-dummy_hash.R
@@ -145,20 +145,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_dummy_hash(
-      all_predictors(),
-      signed = hardhat::tune(),
-      num_terms = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -225,4 +211,19 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_dummy_hash(
+      all_predictors(),
+      signed = hardhat::tune(),
+      num_terms = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-ngram.R
+++ b/tests/testthat/test-ngram.R
@@ -250,19 +250,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_ngram(
-      all_predictors(),
-      num_tokens = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 1L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -329,4 +316,18 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_ngram(
+      all_predictors(),
+      num_tokens = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 1L)
 })

--- a/tests/testthat/test-texthash.R
+++ b/tests/testthat/test-texthash.R
@@ -131,20 +131,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_texthash(
-      all_predictors(),
-      signed = hardhat::tune(),
-      num_terms = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -217,4 +203,19 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_texthash(
+      all_predictors(),
+      signed = hardhat::tune(),
+      num_terms = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-tf.R
+++ b/tests/testthat/test-tf.R
@@ -180,20 +180,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_tf(
-      all_predictors(),
-      weight_scheme = hardhat::tune(),
-      weight = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -260,4 +246,19 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_tf(
+      all_predictors(),
+      weight_scheme = hardhat::tune(),
+      weight = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-tokenfilter.R
+++ b/tests/testthat/test-tokenfilter.R
@@ -132,21 +132,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_tokenfilter(
-      all_predictors(),
-      max_times = hardhat::tune(),
-      min_times = hardhat::tune(),
-      max_tokens = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 3L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -213,4 +198,20 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_tokenfilter(
+      all_predictors(),
+      max_times = hardhat::tune(),
+      min_times = hardhat::tune(),
+      max_tokens = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 3L)
 })

--- a/tests/testthat/test-tokenize.R
+++ b/tests/testthat/test-tokenize.R
@@ -141,19 +141,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_tokenize(
-      all_predictors(),
-      token = hardhat::tune()
-    )
-  
-  params <- extract_parameter_set_dials(rec)
-  
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 1L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -213,4 +200,18 @@ test_that("printing", {
   
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_tokenize(
+      all_predictors(),
+      token = hardhat::tune()
+    )
+  
+  params <- extract_parameter_set_dials(rec)
+  
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 1L)
 })


### PR DESCRIPTION
ref: https://github.com/tidymodels/recipes/pull/1148

This PR aligns the title of the tests with {recipes} and adds missing `skip_if_not_installed("dials")`