### PR TITLE
Avoid nested `unwind_protect()` and unsafe `string` usage

### DIFF
--- a/src/ngram.cpp
+++ b/src/ngram.cpp
@@ -11,26 +11,44 @@ fill_one_ngram(const cpp11::strings& x,
   const R_xlen_t x_size = x.size();
   const R_xlen_t range = std::max(x_size - n + 1, static_cast<R_xlen_t>(0));
   
-  // Not strictly necessary to call `unwind_protect()` here because we also
-  // call it in `cpp11_ngram()`, but it seems like it would be good practice
-  // to call it here too because this is where we leave cpp11 and use the less
-  // safe but faster R API directly.
+  std::string out_elt;
+  
+  // Using `unwind_protect()` manually because character vector extraction and
+  // insertion is currently quite slow in cpp11 due to how protection of each
+  // CHARSXP is handled. We are very careful to:
+  // - Not use any of the cpp11 API here
+  // - Avoid exceptions that could be thrown by `std::string` operations
+  // - Avoid `std::string` creation inside `unwind_protect()`, because its
+  //   destructor would not run if an R error occurred.
   cpp11::unwind_protect([&] {
     for (R_xlen_t i = 0; i < range; ++i) {
       // `x[i]` goes through `r_string`, and that is too expensive because
       // generating each `r_string` involves protecting each CHARSXP.
-      std::string elt = CHAR(STRING_ELT(x, i));
+      const char* elt = CHAR(STRING_ELT(x, i));
+      
+      try {
+        out_elt.clear();
+        out_elt.assign(elt);
+      } catch (...) {
+        Rf_errorcall(R_NilValue, "C++ error while assigning.");
+      }
       
       for (R_xlen_t j = 1; j < n; ++j) {
-        const std::string piece = CHAR(STRING_ELT(x, i + j));
-        elt = elt + delim + piece;
+        const char* piece = CHAR(STRING_ELT(x, i + j));
+        
+        try {
+          out_elt = out_elt + delim + piece;
+        } catch (...) {
+          Rf_errorcall(R_NilValue, "C++ error while concatenating.");
+        }
       }
       
       // `out[i] = elt` would approximately do the same thing, but it goes
       // through `std::string elt` -> `r_string` before assigning, and that
       // again involves protecting each `r_string`, which is expensive and not
       // necessary.
-      SET_STRING_ELT(out, loc, Rf_mkCharLenCE(elt.data(), elt.size(), CE_UTF8));
+      // We don't expect `.data()` or `.size()` to ever throw exceptions.
+      SET_STRING_ELT(out, loc, Rf_mkCharLenCE(out_elt.data(), out_elt.size(), CE_UTF8));
       ++loc;
     }
   });
@@ -78,15 +96,9 @@ cpp11_ngram(cpp11::list_of<cpp11::strings> x,
   const R_xlen_t x_size = x.size();
   cpp11::writable::list_of<cpp11::writable::strings> out(x_size);
   
-  // Calling `unwind_protect()` here because each call to `ngram()` allocates
-  // a `cpp11::writable::strings` vector, and that allocation calls
-  // `unwind_protect()` too, so `unwind_protect()` would be run `x_size` times.
-  // Calling it here "turns off" the nested inner calls to it.
-  cpp11::unwind_protect([&] {
-    for (R_xlen_t i = 0; i < x_size; ++i) {
-      out[i] = ngram(x[i], n, n_min, delim);
-    }
-  });
+  for (R_xlen_t i = 0; i < x_size; ++i) {
+    out[i] = ngram(x[i], n, n_min, delim);
+  }
   
   return(out);
 }


### PR DESCRIPTION
We have taken a long hard look at manual usage of `unwind_protect()` in cpp11 and determined that it is unsafe to use it in a "nested" way. Indeed, if you were to put an `Rf_error()` call (imitating an R error) inside the `unwind_protect()` call of `fill_one_ngram()`, then it causes R to crash. So once thing this PR does is remove the outer `unwind_protect()` call, which wasn't actually impacting performance much.

In https://github.com/r-lib/cpp11/pull/327 we have some new FAQ recommendations that advise against calling `unwind_protect()` yourself _at all_ if possible, with the one exception of character vector manipulation, as we have here.

It is fairly hard to call `unwind_protect()` yourself in a safe way, you have to be careful not to violate these rules:
- You can't use the cpp11 API inside it
- You can't throw exceptions
- You can't create objects that have destructors

We actually violated 2 of these here.
- `std::string` objects were being created inside the `unwind_protect()` and those have destructors. If an R error was thrown from inside the unwind-protect, then that destructor would not be run and you'd get a memory leak. I've worked around this by moving the `std::string` declaration out of the unwind-protect, which should allow its destructor to always run.
- Secondly, `std::string` methods like the `+` method can throw exceptions in rare cases. One way to avoid this is to use pure C here instead, but that is somewhat difficult, so instead I wrapped the places where exceptions were possible in a try/catch, which avoids throwing the exception across a C stack frame (which is undefined behavior). I tried manually adding in `throw std::runtime_error("oh no")` and it does indeed catch the exception safely.

I am sending in a new update of cpp11 in soon. I don't think it actually breaks textrecipes, but you should probably try to get this release in sooner rather than later just to be on the safe side (since these problems are present regardless of the version of cpp11 you have)