### PR TITLE
add keep_original_cols argument to step_tokenmerge()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed bug where `vocabulary_size` wasn't tunable in `step_tokenize_bpe()`. (#239)
 
+* The `keep_original_cols` argument has been added to `step_tokenmerge`. This change should mean that every step that produces new columns has the `keep_original_cols` argument. (#242)
+
 # textrecipes 1.0.3
 
 ## Improvements

--- a/R/tokenmerge.R
+++ b/R/tokenmerge.R
@@ -10,6 +10,7 @@
 #' @template args-trained
 #' @template args-columns
 #' @param prefix A prefix for generated column names, default to "tokenmerge".
+#' @template args-keep_original_cols
 #' @template args-skip
 #' @template args-id
 #'
@@ -51,6 +52,7 @@ step_tokenmerge <-
            trained = FALSE,
            columns = NULL,
            prefix = "tokenmerge",
+           keep_original_cols = FALSE,
            skip = FALSE,
            id = rand_id("tokenmerge")) {
     add_step(
@@ -61,6 +63,7 @@ step_tokenmerge <-
         trained = trained,
         columns = columns,
         prefix = prefix,
+        keep_original_cols = keep_original_cols,
         skip = skip,
         id = id
       )
@@ -68,7 +71,7 @@ step_tokenmerge <-
   }
 
 step_tokenmerge_new <-
-  function(terms, role, trained, columns, prefix,
+  function(terms, role, trained, columns, prefix, keep_original_cols,
            skip, id) {
     step(
       subclass = "tokenmerge",
@@ -77,6 +80,7 @@ step_tokenmerge_new <-
       trained = trained,
       columns = columns,
       prefix = prefix,
+      keep_original_cols = keep_original_cols,
       skip = skip,
       id = id
     )
@@ -94,6 +98,7 @@ prep.step_tokenmerge <- function(x, training, info = NULL, ...) {
     trained = TRUE,
     columns = col_names,
     prefix = x$prefix,
+    keep_original_cols = get_keep_original_cols(x),
     skip = x$skip,
     id = x$id
   )
@@ -115,9 +120,12 @@ bake.step_tokenmerge <- function(object, new_data, ...) {
   new_col <- tibble(tokenlist(new_col))
   names(new_col) <- object$prefix
 
-  new_data <-
-    new_data[, !(colnames(new_data) %in% col_names), drop = FALSE]
-
+  keep_original_cols <- get_keep_original_cols(object)
+  if (!keep_original_cols) {
+    new_data <-
+      new_data[, !(colnames(new_data) %in% col_names), drop = FALSE]
+  }
+  
   new_col <- check_name(new_col, new_data, object, names(new_col))
   
   new_data <- vec_cbind(new_data, new_col)

--- a/man/step_tokenmerge.Rd
+++ b/man/step_tokenmerge.Rd
@@ -11,6 +11,7 @@ step_tokenmerge(
   trained = FALSE,
   columns = NULL,
   prefix = "tokenmerge",
+  keep_original_cols = FALSE,
   skip = FALSE,
   id = rand_id("tokenmerge")
 )
@@ -36,6 +37,9 @@ be populated (eventually) by the \code{terms} argument. This is \code{NULL}
 until the step is trained by \code{\link[recipes:prep]{recipes::prep.recipe()}}.}
 
 \item{prefix}{A prefix for generated column names, default to "tokenmerge".}
+
+\item{keep_original_cols}{A logical to keep the original variables in the
+output. Defaults to \code{FALSE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked

--- a/tests/testthat/_snaps/dummy_hash.md
+++ b/tests/testthat/_snaps/dummy_hash.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  dummyhash_text_01
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_dummy_hash()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -50,6 +42,14 @@
       
       -- Operations 
       * Feature hashing with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_dummy_hash()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/lda.md
+++ b/tests/testthat/_snaps/lda.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  lda_text_1
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = tate_text, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_lda()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -50,6 +42,14 @@
       
       -- Operations 
       * Text feature extraction for: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_lda()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/sequence_onehot.md
+++ b/tests/testthat/_snaps/sequence_onehot.md
@@ -37,14 +37,6 @@
       ! Name collision occured. The following variable names already exists:
       i  seq1hot_text_1
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_sequence_onehot()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -79,6 +71,14 @@
       
       -- Operations 
       * Sequence 1 hot encoding for: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_sequence_onehot()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/textfeature.md
+++ b/tests/testthat/_snaps/textfeature.md
@@ -29,14 +29,6 @@
       ! Name collision occured. The following variable names already exists:
       i  textfeature_text_n_words
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_textfeature()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -71,6 +63,22 @@
       
       -- Operations 
       * Text feature extraction for: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_tf()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
+---
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_textfeature()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/texthash.md
+++ b/tests/testthat/_snaps/texthash.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  texthash_text_0001
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_texthash()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -50,6 +42,14 @@
       
       -- Operations 
       * Feature hashing with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_texthash()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/tf.md
+++ b/tests/testthat/_snaps/tf.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  tf_text_i
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_tf()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -50,6 +42,14 @@
       
       -- Operations 
       * Term frequency with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_tf()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/tfidf.md
+++ b/tests/testthat/_snaps/tfidf.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  tfidf_text_i
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_tfidf()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # Backwards compatibility with 1592690d36581fc5f4952da3e9b02351b31f1a2e
 
     Code
@@ -68,6 +60,14 @@
       
       -- Operations 
       * Term frequency-inverse document frequency with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_tfidf()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/tokenmerge.md
+++ b/tests/testthat/_snaps/tokenmerge.md
@@ -52,6 +52,14 @@
       -- Operations 
       * Merging tokens for: <none> | Trained
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_tokenmerge()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/word_embeddings.md
+++ b/tests/testthat/_snaps/word_embeddings.md
@@ -8,14 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  wordembed_text_d1
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-    Warning <rlang_warning>
-      'keep_original_cols' was added to `step_word_embeddings()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -50,6 +42,14 @@
       
       -- Operations 
       * Word embeddings aggregated from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Warning <rlang_warning>
+      'keep_original_cols' was added to `step_word_embeddings()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/test-dummy_hash.R
+++ b/tests/testthat/test-dummy_hash.R
@@ -96,40 +96,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  koc_rec <- rec %>%
-    step_dummy_hash(sponsor_code, num_terms = 4, keep_original_cols = TRUE)
-
-  koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-
-  koc_pred <- bake(koc_trained, new_data = test_data, all_predictors())
-
-  expect_equal(
-    colnames(koc_pred),
-    c(
-      "contract_value_band", "sponsor_code", "dummyhash_sponsor_code_1", 
-      "dummyhash_sponsor_code_2", "dummyhash_sponsor_code_3",
-      "dummyhash_sponsor_code_4"
-    )
-  )
-})
-
-test_that("can prep recipes with no keep_original_cols", {
-  koc_rec <- rec %>%
-    step_dummy_hash(sponsor_code, keep_original_cols = TRUE)
-
-  koc_rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-  )
-
-  expect_error(
-    pca_pred <- bake(koc_trained, new_data = test_data, all_predictors()),
-    NA
-  )
-})
-
 test_that("tunable", {
   rec <-
     recipe(~., data = mtcars) %>%
@@ -203,6 +169,53 @@ test_that("empty selection tidy method works", {
   
   expect_identical(tidy(rec, number = 1), expect)
 })
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("text2vec")
+  
+  new_names <- paste0("dummyhash_sponsor_code_", 1:5)
+  
+  rec <- recipe(~ sponsor_code, data = test_data) %>%
+    step_dummy_hash(sponsor_code, num_terms = 5, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~ sponsor_code, data = test_data) %>%
+    step_dummy_hash(sponsor_code, num_terms = 5, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("sponsor_code", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("text2vec")
+  
+  rec <- recipe(~ sponsor_code, data = test_data) %>%
+    step_dummy_hash(sponsor_code)
+  
+  rec$steps[[1]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
+})
+
 
 test_that("printing", {
   skip_if_not_installed("text2vec")

--- a/tests/testthat/test-sequence_onehot.R
+++ b/tests/testthat/test-sequence_onehot.R
@@ -134,41 +134,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  koc_rec <- rec %>%
-    step_tokenize(text) %>%
-    step_sequence_onehot(text, sequence_length = 5, keep_original_cols = TRUE)
-
-  koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-
-  koc_pred <- bake(koc_trained, new_data = test_data, all_predictors())
-
-  expect_equal(
-    colnames(koc_pred),
-    c(
-      "text", "seq1hot_text_1", "seq1hot_text_2", "seq1hot_text_3",
-      "seq1hot_text_4", "seq1hot_text_5"
-    )
-  )
-})
-
-test_that("can prep recipes with no keep_original_cols", {
-  koc_rec <- rec %>%
-    step_tokenize(text) %>%
-    step_sequence_onehot(text, sequence_length = 5, keep_original_cols = TRUE)
-
-  koc_rec$steps[[2]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-  )
-
-  expect_error(
-    pca_pred <- bake(koc_trained, new_data = test_data, all_predictors()),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -232,6 +197,52 @@ test_that("empty selection tidy method works", {
   
   expect_identical(tidy(rec, number = 1), expect)
 })
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("seq1hot_text_", 1:100)
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_sequence_onehot(text, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_sequence_onehot(text, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_sequence_onehot(text)
+  
+  rec$steps[[2]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
+})
+
 
 test_that("printing", {
   rec <- rec %>%

--- a/tests/testthat/test-textfeature.R
+++ b/tests/testthat/test-textfeature.R
@@ -80,41 +80,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  koc_rec <- rec %>%
-    step_textfeature(text,
-      extract_functions = list(nchar = nchar),
-      keep_original_cols = TRUE
-    )
-
-  koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-
-  koc_pred <- bake(koc_trained, new_data = test_data, all_predictors())
-
-  expect_equal(
-    colnames(koc_pred),
-    c(
-      "text", "textfeature_text_nchar"
-    )
-  )
-})
-
-test_that("can prep recipes with no keep_original_cols", {
-  koc_rec <- rec %>%
-    step_textfeature(text, keep_original_cols = TRUE)
-
-  koc_rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-  )
-
-  expect_error(
-    pca_pred <- bake(koc_trained, new_data = test_data, all_predictors()),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -171,6 +136,102 @@ test_that("empty selection tidy method works", {
   
   expect_identical(tidy(rec, number = 1), expect)
 })
+
+test_that("keep_original_cols works", {
+  new_names <- c(
+    "tf_text_am", "tf_text_and", "tf_text_anywhere", "tf_text_do", 
+    "tf_text_eat", "tf_text_eggs", "tf_text_green", "tf_text_ham", 
+    "tf_text_here", "tf_text_i", "tf_text_like", "tf_text_not", "tf_text_or", 
+    "tf_text_sam", "tf_text_them", "tf_text_there", "tf_text_would"
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tf(text, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tf(text, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tf(text)
+  
+  rec$steps[[2]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
+})
+test_that("keep_original_cols works", {
+  skip_if_not_installed("textfeatures")
+  
+  new_names <- paste0("textfeature_text_", names(textfeatures::count_functions))
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_textfeature(text, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_textfeature(text, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("textfeatures")
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_textfeature(text)
+  
+  rec$steps[[1]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
+})
+
 
 test_that("printing", {
   skip_if_not_installed("textfeatures")

--- a/tests/testthat/test-tfidf.R
+++ b/tests/testthat/test-tfidf.R
@@ -79,46 +79,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  koc_rec <- rec %>%
-    step_tokenize(text) %>%
-    step_tfidf(text, keep_original_cols = TRUE)
-
-  koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-
-  koc_pred <- bake(koc_trained, new_data = test_data, all_predictors())
-
-  expect_equal(
-    colnames(koc_pred),
-    c(
-      c(
-        "text", "tfidf_text_am", "tfidf_text_and", "tfidf_text_anywhere",
-        "tfidf_text_do", "tfidf_text_eat", "tfidf_text_eggs", "tfidf_text_green",
-        "tfidf_text_ham", "tfidf_text_here", "tfidf_text_i", "tfidf_text_like",
-        "tfidf_text_not", "tfidf_text_or", "tfidf_text_sam", "tfidf_text_them",
-        "tfidf_text_there", "tfidf_text_would"
-      )
-    )
-  )
-})
-
-test_that("can prep recipes with no keep_original_cols", {
-  koc_rec <- rec %>%
-    step_tokenize(text) %>%
-    step_tfidf(text, keep_original_cols = TRUE)
-
-  koc_rec$steps[[2]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-  )
-
-  expect_error(
-    pca_pred <- bake(koc_trained, new_data = test_data, all_predictors()),
-    NA
-  )
-})
-
 test_that("idf valeus are trained on training data and applied on test data", {
   data <- tibble(text = c("i g", "i i i"))
 
@@ -228,6 +188,57 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
   
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c(
+    "tfidf_text_am", "tfidf_text_and", "tfidf_text_anywhere", "tfidf_text_do", 
+    "tfidf_text_eat", "tfidf_text_eggs", "tfidf_text_green", "tfidf_text_ham", 
+    "tfidf_text_here", "tfidf_text_i", "tfidf_text_like", "tfidf_text_not", 
+    "tfidf_text_or", "tfidf_text_sam", "tfidf_text_them", "tfidf_text_there", 
+    "tfidf_text_would"
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tfidf(text, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tfidf(text, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_tfidf(text)
+  
+  rec$steps[[2]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-tokenmerge.R
+++ b/tests/testthat/test-tokenmerge.R
@@ -125,6 +125,51 @@ test_that("empty selection tidy method works", {
   expect_identical(tidy(rec, number = 1), expect)
 })
 
+test_that("keep_original_cols works", {
+  new_names <- c("tokenmerge")
+  
+  rec <-  recipe(~., data = test_data) %>%
+    step_tokenize(text1, text2) %>%
+    step_tokenmerge(text1, text2, keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~., data = test_data) %>%
+    step_tokenize(text1, text2) %>%
+    step_tokenmerge(text1, text2, keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text1", "text2", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~., data = test_data) %>%
+    step_tokenize(text1, text2) %>%
+    step_tokenmerge(text1, text2)
+  
+  rec$steps[[2]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
+})
+
 test_that("printing", {
   rec <- rec %>%
     step_tokenize(text1, text2) %>%

--- a/tests/testthat/test-word_embeddings.R
+++ b/tests/testthat/test-word_embeddings.R
@@ -271,47 +271,6 @@ test_that("aggregation_default argument works", {
   )
 })
 
-test_that("keep_original_cols works", {
-  koc_rec <- recipe(~text, data = test_data) %>%
-    step_tokenize(text) %>%
-    step_word_embeddings(text,
-      embeddings = embeddings, aggregation = "mean",
-      keep_original_cols = TRUE
-    )
-
-  koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-
-  koc_pred <- bake(koc_trained, new_data = test_data, all_predictors())
-
-  expect_equal(
-    colnames(koc_pred),
-    c(
-      "text", "wordembed_text_d1", "wordembed_text_d2", "wordembed_text_d3",
-      "wordembed_text_d4", "wordembed_text_d5"
-    )
-  )
-})
-
-test_that("can prep recipes with no keep_original_cols", {
-  koc_rec <- recipe(~text, data = test_data) %>%
-    step_tokenize(text) %>%
-    step_word_embeddings(text,
-      embeddings = embeddings, aggregation = "mean",
-      keep_original_cols = TRUE
-    )
-
-  koc_rec$steps[[2]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    koc_trained <- prep(koc_rec, training = test_data, verbose = FALSE)
-  )
-
-  expect_error(
-    pca_pred <- bake(koc_trained, new_data = test_data, all_predictors()),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -374,6 +333,56 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
   
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("wordembed_text_d", 1:5)
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_word_embeddings(text,
+                         embeddings = embeddings, aggregation = "mean",
+                         keep_original_cols = FALSE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+  
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_word_embeddings(text,
+                         embeddings = embeddings, aggregation = "mean",
+                         keep_original_cols = TRUE)
+  
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+  
+  expect_equal(
+    colnames(res),
+    c("text", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~text, data = test_data) %>%
+    step_tokenize(text) %>%
+    step_word_embeddings(text,
+                         embeddings = embeddings, aggregation = "mean")
+  
+  rec$steps[[2]]$keep_original_cols <- NULL
+  
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+  
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
 })
 
 test_that("printing", {


### PR DESCRIPTION
This PR additionally makes sure all the `keep_original_cols` testing is up to date