### PR TITLE
Make `step_textfeatures()` faster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Calling `?tidy.step_*()` now sends you to the documentation for `step_*()` where the outcome is documented. (#261)
 
+* `step_textfeatures()` has been made faster and more robust. #265
+
 # textrecipes 1.0.6
 
 * textfeatures has been removed from Suggests. (#255)

--- a/R/count_functions.R
+++ b/R/count_functions.R
@@ -40,14 +40,8 @@ n_mentions <- function(x) {
 }
 
 n_uq_mentions <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("@\\S+", x)
-  x <- regmatches(x, m)
-  x <- lapply(x, unique)
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_extract_all_regex(x, "@\\S+", omit_no_match = TRUE)
+  purrr::map_int(x, dplyr::n_distinct)
 }
 
 n_commas <- function(x) {
@@ -79,14 +73,8 @@ n_urls <- function(x) {
 }
 
 n_uq_urls <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("https?", x)
-  x <- regmatches(x, m)
-  x <- lapply(x, unique)
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_extract_all_regex(x, "https?", omit_no_match = TRUE)
+  purrr::map_int(x, dplyr::n_distinct)
 }
 
 n_nonasciis <- function(x) {
@@ -95,7 +83,7 @@ n_nonasciis <- function(x) {
 }
 
 n_puncts <- function(x) {
-  x <- gsub("!|\\.|\\,", "", x)
+  x <- stringi::stri_replace_all_regex(x, "!|\\.|\\,", "")
   stringi::stri_count_regex(x, "[[:punct:]]")
 }
 

--- a/R/count_functions.R
+++ b/R/count_functions.R
@@ -1,23 +1,10 @@
 n_words <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  x <- gsub("\\d", "", x)
-  x <- strsplit(x, "\\s+")
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_words(x)
 }
 
-
 n_uq_words <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  x <- gsub("\\d", "", x)
-  x <- strsplit(x, "\\s+")
-  x <- lapply(x, unique)
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_extract_all_words(x)
+  purrr::map_int(x, dplyr::n_distinct)
 }
 
 n_charS <- function(x) {

--- a/R/count_functions.R
+++ b/R/count_functions.R
@@ -42,22 +42,12 @@ n_uq_charS <- function(x) {
 
 
 n_digits <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("\\d", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "\\d")
 }
 
 
 n_hashtags <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("#[[:alnum:]_]+", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "#[[:alnum:]_]+")
 }
 
 n_uq_hashtags <- function(x) {
@@ -72,12 +62,7 @@ n_uq_hashtags <- function(x) {
 }
 
 n_mentions <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("@\\S+", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "@\\S+")
 }
 
 n_uq_mentions <- function(x) {
@@ -92,66 +77,31 @@ n_uq_mentions <- function(x) {
 }
 
 n_commas <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr(",", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_fixed(x, ",")
 }
 
 n_periods <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("\\.", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_fixed(x, ".")
 }
 
 n_exclaims <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("\\!", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_fixed(x, "!")
 }
 
 n_extraspaces <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("\\s{2}|\\t|\\n", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "\\s{2}|\\t|\\n")
 }
 
 n_caps <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("[[:upper:]]", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "[[:upper:]]")
 }
 
 n_lowers <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("[[:lower:]]", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "[[:lower:]]")
 }
 
 n_urls <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("https?", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "https?")
 }
 
 n_uq_urls <- function(x) {
@@ -166,23 +116,13 @@ n_uq_urls <- function(x) {
 }
 
 n_nonasciis <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
   x <- iconv(x, from = "UTF-8", to = "ASCII", sub = "[NONASCII]")
-  m <- gregexpr("\\[NONASCII\\]", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "\\[NONASCII\\]")
 }
 
 n_puncts <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
   x <- gsub("!|\\.|\\,", "", x)
-  m <- gregexpr("[[:punct:]]", x)
-  x <- purrr::map_int(m, ~ sum(.x > 0, na.rm = TRUE))
-  x[na] <- NA_integer_
-  x
+  stringi::stri_count_regex(x, "[[:punct:]]")
 }
 
 first_person <- function(x) {

--- a/R/count_functions.R
+++ b/R/count_functions.R
@@ -8,25 +8,18 @@ n_uq_words <- function(x) {
 }
 
 n_charS <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  x <- gsub("\\s", "", x)
-  x <- nchar(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_replace_all_regex(x, "\\s", "")
+  nchar(x)
 }
 
 n_uq_charS <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  x <- gsub("\\s", "", x)
-  x <- strsplit(x, "")
-  x <- lapply(x, unique)
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_replace_all_regex(x, "\\s", "")
+  x <- stringi::stri_split_boundaries(
+    x,
+    opts_brkiter = stringi::stri_opts_brkiter(type = "character")
+  )
+  purrr::map_int(x, dplyr::n_distinct)
 }
-
 
 n_digits <- function(x) {
   stringi::stri_count_regex(x, "\\d")
@@ -38,14 +31,8 @@ n_hashtags <- function(x) {
 }
 
 n_uq_hashtags <- function(x) {
-  na <- is.na(x)
-  if (all(na)) return(0)
-  m <- gregexpr("#[[:alnum:]_]+", x)
-  x <- regmatches(x, m)
-  x <- lapply(x, unique)
-  x <- lengths(x)
-  x[na] <- NA_integer_
-  x
+  x <- stringi::stri_extract_all_regex(x, "#[[:alnum:]_]+", omit_no_match = TRUE)
+  purrr::map_int(x, dplyr::n_distinct)
 }
 
 n_mentions <- function(x) {

--- a/R/tokenize_bpe.R
+++ b/R/tokenize_bpe.R
@@ -161,7 +161,7 @@ check_bpe_vocab_size <- function(text,
     rlang::abort(
       glue(
         "`vocabulary_size` of {vocabulary_size} is too small for column ",
-        "`{column}` which has a unique character count of {text_count}",
+        "`{column}` which has a unique character count of {text_count}"
       ),
       call = call
     )

--- a/tests/testthat/_snaps/textfeature.md
+++ b/tests/testthat/_snaps/textfeature.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_textfeature()`:
       Caused by error in `prep()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `text` doesn't exist.
 
 ---
@@ -16,7 +16,7 @@
     Condition
       Error in `step_textfeature()`:
       Caused by error in `prep()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `text` doesn't exist.
 
 # check_name() is used


### PR DESCRIPTION
I found that a big part of the slowness of https://github.com/tidymodels/tidymodels.org/issues/27 came from `step_textfeatures()`, this PR aims to deal with that issue


```r
library(tidymodels)
library(textrecipes)

data("small_fine_foods")

rec <- recipe(~review, data = training_data) |>
  step_textfeature(review)

bench::mark(
  prep(rec)
)

# Before
# A tibble: 1 × 13
# expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
# <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
# 1 prep(rec)     1.59s    1.59s     0.628     679MB     6.28     1    10
# ℹ 5 more variables: total_time <bch:tm>, result <list>, memory <list>,
#   time <list>, gc <list>

# Now
# A tibble: 1 × 13
# expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
# <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
# 1 prep(rec)     630ms    630ms      1.59    48.2MB     7.94     1     5
# ℹ 5 more variables: total_time <bch:tm>, result <list>, memory <list>,
#   time <list>, gc <list>
```