### PR TITLE
More snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ URL: https://github.com/tidymodels/textrecipes,
 BugReports: https://github.com/tidymodels/textrecipes/issues
 Depends: 
     R (>= 3.6),
-    recipes (>= 1.0.7)
+    recipes (>= 1.1.0.9000)
 Imports: 
     lifecycle,
     dplyr,
@@ -53,6 +53,8 @@ Suggests:
     tokenizers.bpe,
     udpipe,
     wordpiece
+Remotes:
+    tidymodels/recipes
 LinkingTo: 
     cpp11
 VignetteBuilder: 

--- a/tests/testthat/_snaps/R4.4/tokenize_bpe.md
+++ b/tests/testthat/_snaps/R4.4/tokenize_bpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      recipe(~text1, data = test_data) %>% step_tokenize_bpe(text1, vocabulary_size = 10) %>%
+        prep()
+    Condition
+      Error in `step_tokenize_bpe()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 10 is too small for column `text1` which has a unique character count of 23
+

--- a/tests/testthat/_snaps/R4.4/tokenizer-tokenizersbpe.md
+++ b/tests/testthat/_snaps/R4.4/tokenizer-tokenizersbpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      recipe(~text, data = tibble(text = "hello")) %>% step_tokenize(text, engine = "tokenizers.bpe",
+        training_options = list(vocab_size = 2)) %>% prep()
+    Condition
+      Error in `step_tokenize()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 2 is too small for column `text` which has a unique character count of 4
+

--- a/tests/testthat/_snaps/clean_levels.md
+++ b/tests/testthat/_snaps/clean_levels.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = smith_tr[, -1])
+    Condition
+      Error in `step_clean_levels()`:
+      ! The following required column is missing from `new_data`: name.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/clean_names.md
+++ b/tests/testthat/_snaps/clean_names.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_clean_names()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy_hash.md
+++ b/tests/testthat/_snaps/dummy_hash.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `dummyhash_text_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -2])
+    Condition
+      Error in `step_dummy_hash()`:
+      ! The following required column is missing from `new_data`: sponsor_code.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/lda.md
+++ b/tests/testthat/_snaps/lda.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `lda_text_1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_lda()`:
+      ! The following required column is missing from `new_data`: medium.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/lemma.md
+++ b/tests/testthat/_snaps/lemma.md
@@ -7,6 +7,14 @@
       Caused by error in `bake()`:
       ! `text` doesn't have a lemma attribute. Make sure the tokenization step includes lemmatization.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_lemma()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/ngram.md
+++ b/tests/testthat/_snaps/ngram.md
@@ -14,6 +14,14 @@
       Error:
       ! n must be a positive integer.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_ngram()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/pos_filter.md
+++ b/tests/testthat/_snaps/pos_filter.md
@@ -7,6 +7,14 @@
       Caused by error in `bake()`:
       ! `text` doesn't have a pos attribute. Make sure the tokenization step includes part of speech tagging.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_pos_filter()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/sequence_onehot.md
+++ b/tests/testthat/_snaps/sequence_onehot.md
@@ -41,6 +41,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `seq1hot_text_1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_sequence_onehot()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/stem.md
+++ b/tests/testthat/_snaps/stem.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_stem()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/stopwords.md
+++ b/tests/testthat/_snaps/stopwords.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_stopwords()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/text_normalization.md
+++ b/tests/testthat/_snaps/text_normalization.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = ex_dat[, -1])
+    Condition
+      Error in `step_text_normalization()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/textfeature.md
+++ b/tests/testthat/_snaps/textfeature.md
@@ -29,6 +29,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `textfeature_text_n_words`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -1])
+    Condition
+      Error in `step_textfeature()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/texthash.md
+++ b/tests/testthat/_snaps/texthash.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `texthash_text_0001`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_texthash()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tf.md
+++ b/tests/testthat/_snaps/tf.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `tf_text_i`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_tf()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tfidf.md
+++ b/tests/testthat/_snaps/tfidf.md
@@ -28,6 +28,14 @@
       Please retrain this recipe with version 0.5.1 or higher.
       * A data leakage bug has been fixed for `step_tfidf()`.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_tfidf()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenfilter.md
+++ b/tests/testthat/_snaps/tokenfilter.md
@@ -36,6 +36,14 @@
       * Tokenization for: text | Trained
       * Text filtering for: text | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_tokenfilter()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenize.md
+++ b/tests/testthat/_snaps/tokenize.md
@@ -16,6 +16,14 @@
       Caused by error in `prep()`:
       ! `engine` argument is not valid.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -1])
+    Condition
+      Error in `step_tokenize()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenize_bpe.md
+++ b/tests/testthat/_snaps/tokenize_bpe.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -1])
+    Condition
+      Error in `step_tokenize_bpe()`:
+      ! The following required column is missing from `new_data`: text1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenize_sentencepiece.md
+++ b/tests/testthat/_snaps/tokenize_sentencepiece.md
@@ -8,6 +8,14 @@
       Caused by error in `prep()`:
       ! `vocabulary_size` of 10 is too small for column `text1` which has a unique character count of 23.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -1])
+    Condition
+      Error in `step_tokenize_sentencepiece()`:
+      ! The following required column is missing from `new_data`: text1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenize_wordpiece.md
+++ b/tests/testthat/_snaps/tokenize_wordpiece.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = test_data[, -1])
+    Condition
+      Error in `step_tokenize_wordpiece()`:
+      ! The following required column is missing from `new_data`: text1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/tokenmerge.md
+++ b/tests/testthat/_snaps/tokenmerge.md
@@ -18,6 +18,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `tokenmerge`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_tokenmerge()`:
+      ! The following required column is missing from `new_data`: text1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/untokenize.md
+++ b/tests/testthat/_snaps/untokenize.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_untokenize()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/word_embeddings.md
+++ b/tests/testthat/_snaps/word_embeddings.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `wordembed_text_d1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = tokenized_test_data[, -1])
+    Condition
+      Error in `step_word_embeddings()`:
+      ! The following required column is missing from `new_data`: text.
+
 # empty printing
 
     Code

--- a/tests/testthat/test-clean_levels.R
+++ b/tests/testthat/test-clean_levels.R
@@ -77,9 +77,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = smith_tr, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = smith_tr[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = smith_tr[, -1])
   )
 })
 

--- a/tests/testthat/test-clean_names.R
+++ b/tests/testthat/test-clean_names.R
@@ -42,9 +42,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec)
   
-  expect_error(
-    bake(trained, new_data = mtcars[, -3]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = mtcars[, -3])
   )
 })
 

--- a/tests/testthat/test-dummy_hash.R
+++ b/tests/testthat/test-dummy_hash.R
@@ -231,9 +231,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-dummy_hash.R
+++ b/tests/testthat/test-dummy_hash.R
@@ -138,9 +138,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = test_data[, -2]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -2])
   )
 })
 

--- a/tests/testthat/test-lda.R
+++ b/tests/testthat/test-lda.R
@@ -81,9 +81,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-lda.R
+++ b/tests/testthat/test-lda.R
@@ -175,9 +175,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = tate_text[seq_len(n_rows), ]),
-    NA
+  expect_no_error(
+    bake(rec, new_data = tate_text[seq_len(n_rows), ])
   )
 })
 

--- a/tests/testthat/test-lemma.R
+++ b/tests/testthat/test-lemma.R
@@ -67,9 +67,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-ngram.R
+++ b/tests/testthat/test-ngram.R
@@ -266,9 +266,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-pos_filter.R
+++ b/tests/testthat/test-pos_filter.R
@@ -113,9 +113,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-sequence_onehot.R
+++ b/tests/testthat/test-sequence_onehot.R
@@ -237,9 +237,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-sequence_onehot.R
+++ b/tests/testthat/test-sequence_onehot.R
@@ -150,9 +150,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-stem.R
+++ b/tests/testthat/test-stem.R
@@ -87,9 +87,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-stopwords.R
+++ b/tests/testthat/test-stopwords.R
@@ -92,9 +92,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-text_normalization.R
+++ b/tests/testthat/test-text_normalization.R
@@ -28,9 +28,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = ex_dat, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = ex_dat[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = ex_dat[, -1])
   )
 })
 

--- a/tests/testthat/test-textfeature.R
+++ b/tests/testthat/test-textfeature.R
@@ -87,9 +87,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-textfeature.R
+++ b/tests/testthat/test-textfeature.R
@@ -178,9 +178,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 test_that("keep_original_cols works", {
@@ -219,9 +218,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-texthash.R
+++ b/tests/testthat/test-texthash.R
@@ -124,9 +124,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-texthash.R
+++ b/tests/testthat/test-texthash.R
@@ -215,9 +215,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-tf.R
+++ b/tests/testthat/test-tf.R
@@ -246,9 +246,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-tf.R
+++ b/tests/testthat/test-tf.R
@@ -159,9 +159,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tfidf.R
+++ b/tests/testthat/test-tfidf.R
@@ -142,9 +142,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tfidf.R
+++ b/tests/testthat/test-tfidf.R
@@ -235,9 +235,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-tokenfilter.R
+++ b/tests/testthat/test-tokenfilter.R
@@ -148,9 +148,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenize.R
+++ b/tests/testthat/test-tokenize.R
@@ -151,9 +151,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenize_bpe.R
+++ b/tests/testthat/test-tokenize_bpe.R
@@ -158,9 +158,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenize_sentencepiece.R
+++ b/tests/testthat/test-tokenize_sentencepiece.R
@@ -129,9 +129,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenize_wordpiece.R
+++ b/tests/testthat/test-tokenize_wordpiece.R
@@ -70,8 +70,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = test_data, verbose = FALSE)
   
-  expect_error(bake(trained, new_data = test_data[, -1]),
-               class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenmerge.R
+++ b/tests/testthat/test-tokenmerge.R
@@ -83,8 +83,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(bake(trained, new_data = tokenized_test_data[, -1]),
-               class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-tokenmerge.R
+++ b/tests/testthat/test-tokenmerge.R
@@ -165,9 +165,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-untokenize.R
+++ b/tests/testthat/test-untokenize.R
@@ -80,8 +80,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(bake(trained, new_data = tokenized_test_data[, -1]),
-               class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-word_embeddings.R
+++ b/tests/testthat/test-word_embeddings.R
@@ -137,9 +137,8 @@ test_that("step_word_embeddings deals with missing words appropriately.", {
   new_text <- tibble(
     text = "aksjdf nagjli aslkfa"
   )
-  expect_error(
-    bake(obj, new_data = new_text),
-    NA
+  expect_no_error(
+    bake(obj, new_data = new_text)
   )
 })
 
@@ -377,9 +376,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
   
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-word_embeddings.R
+++ b/tests/testthat/test-word_embeddings.R
@@ -287,9 +287,9 @@ test_that("bake method errors when needed non-standard role columns are missing"
   
   trained <- prep(rec, training = tokenized_test_data, verbose = FALSE)
   
-  expect_error(
-    bake(trained, new_data = tokenized_test_data[, -1]),
-    class = "new_data_missing_column"
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = tokenized_test_data[, -1])
   )
 })
 

--- a/tests/testthat/test-word_embeddings.R
+++ b/tests/testthat/test-word_embeddings.R
@@ -127,13 +127,11 @@ test_that("step_word_embeddings deals with missing words appropriately.", {
       "I do not like them, they're not nice."
     )
   )
-  expect_warning(
-    bake(obj, new_data = new_text),
-    NA
+  expect_no_warning(
+    bake(obj, new_data = new_text)
   )
-  expect_warning(
-    bake(obj, new_data = test_data),
-    NA
+  expect_no_warning(
+    bake(obj, new_data = test_data)
   )
 
   new_text <- tibble(


### PR DESCRIPTION
Ref: https://github.com/tidymodels/recipes/pull/1375

This PR:

- switched from `expect_warning()` and `expect_message()` to `expect_snapshot()`
- removed classed `expect_error()` and switched to `expect_snapshot(error = TRUE)`
- Switched from `expect_error(..., NA)` to `expect_no_error()`. Can't do `expect_no_condition()` due to dplyr_regroup signal
- Switched rest of `expect_error()` to `expect_snapshot(error = TRUE)`