### PR TITLE
Remove warning about `max_tokens` in `step_tokenfilter()`

### DIFF
--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -189,8 +189,7 @@ prep.step_tokenfilter <- function(x, training, info = NULL, ...) {
       )
       n_words[[col_name]] <- length(unique(unlist(training[[col_name]])))
     }
-  } else {
-  }
+  } else {}
 
   step_tokenfilter_new(
     terms = x$terms,
@@ -287,10 +286,6 @@ tokenfilter_fun <- function(
     names(sort(tf[ids], decreasing = TRUE))
   } else {
     if (max_tokens > sum(ids)) {
-      cli::cli_warn(
-        "max_tokens was set to {.val {max_tokens}}, but only {sum(ids)} was 
-        available and selected."
-      )
       max_tokens <- sum(ids)
     }
     names(sort(tf[ids], decreasing = TRUE)[seq_len(max_tokens)])

--- a/R/tokenfilter.R
+++ b/R/tokenfilter.R
@@ -189,7 +189,7 @@ prep.step_tokenfilter <- function(x, training, info = NULL, ...) {
       )
       n_words[[col_name]] <- length(unique(unlist(training[[col_name]])))
     }
-  } else {}
+  }
 
   step_tokenfilter_new(
     terms = x$terms,

--- a/tests/testthat/_snaps/tokenfilter.md
+++ b/tests/testthat/_snaps/tokenfilter.md
@@ -2,25 +2,16 @@
 
     Code
       obj <- prep(rec)
-    Condition
-      Warning:
-      max_tokens was set to 100, but only 3 was available and selected.
 
 # removes words correctly with min_times, max_times and procentage
 
     Code
       obj <- prep(rec)
-    Condition
-      Warning:
-      max_tokens was set to 100, but only 12 was available and selected.
 
 # tokenfilter throws warning when max_tokens > words
 
     Code
       prep(rec)
-    Condition
-      Warning:
-      max_tokens was set to 10000, but only 17 was available and selected.
     Message
       
       -- Recipe ----------------------------------------------------------------------
@@ -164,9 +155,6 @@
 
     Code
       prep(rec)
-    Condition
-      Warning:
-      max_tokens was set to 100, but only 17 was available and selected.
     Message
       
       -- Recipe ----------------------------------------------------------------------


### PR DESCRIPTION
- Remove one of the warning about `max_tokens` in `step_tokenfilter()`.
- Remove a few warning conditions for the above in tokenfilter snapshot.

Fixes #300 