### PR TITLE
Speed up step_word_embeddings()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 ^.cache$
 ^[\.]?air\.toml$
 ^\.vscode$
+^bench$

--- a/R/tokenlist.R
+++ b/R/tokenlist.R
@@ -306,16 +306,21 @@ tokenlist_ngram <- function(x, n, n_min, delim) {
   tokenlist(ngram(get_tokens(x), n, n_min, delim))
 }
 
-tokenlist_embedding <- function(x, emb, aggregation, aggregation_default) {
+tokenlist_embedding <- function(
+  x,
+  emb_mat,
+  emb_tokens,
+  aggregation,
+  aggregation_default
+) {
   tokens <- get_tokens(x)
   n_doc <- length(tokens)
-  emb_names <- names(emb)[-1]
+  emb_names <- colnames(emb_mat)
   n_dim <- length(emb_names)
-  emb_mat <- as.matrix(emb[, -1])
 
-  # Map each token occurrence to its document and its row in `emb`.
+  # Map each token occurrence to its document and its row in `emb_mat`.
   doc_id <- rep.int(seq_len(n_doc), lengths(tokens))
-  token_index <- match(unlist(tokens, use.names = FALSE), emb[[1]])
+  token_index <- match(unlist(tokens, use.names = FALSE), emb_tokens)
 
   keep <- !is.na(token_index)
   doc_id <- doc_id[keep]

--- a/R/tokenlist.R
+++ b/R/tokenlist.R
@@ -311,6 +311,7 @@ tokenlist_embedding <- function(x, emb, aggregation, aggregation_default) {
   n_doc <- length(tokens)
   emb_names <- names(emb)[-1]
   n_dim <- length(emb_names)
+  emb_mat <- as.matrix(emb[, -1])
 
   # Map each token occurrence to its document and its row in `emb`.
   doc_id <- rep.int(seq_len(n_doc), lengths(tokens))
@@ -328,32 +329,65 @@ tokenlist_embedding <- function(x, emb, aggregation, aggregation_default) {
   )
 
   if (length(token_index) > 0L) {
-    emb_mat <- as.matrix(emb[, -1])
-    vals <- emb_mat[token_index, , drop = FALSE]
-
-    agg <- aggregate_embedding(vals, doc_id, aggregation)
-    res[as.integer(rownames(agg)), ] <- agg
+    if (aggregation %in% c("sum", "mean")) {
+      res <- aggregate_embedding_linear(
+        emb_mat,
+        doc_id,
+        token_index,
+        n_doc,
+        aggregation,
+        aggregation_default
+      )
+      dimnames(res) <- list(NULL, emb_names)
+    } else {
+      agg <- aggregate_embedding_extremum(
+        emb_mat[token_index, , drop = FALSE],
+        doc_id,
+        aggregation
+      )
+      res[as.integer(rownames(agg)), ] <- agg
+    }
   }
 
   tibble::as_tibble(res)
 }
 
-# Aggregate the rows of `vals` (a numeric matrix) by `group`, returning a matrix
-# with one row per present group and the group label as the row name.
-aggregate_embedding <- function(vals, group, aggregation) {
-  if (aggregation %in% c("sum", "mean")) {
-    out <- rowsum(vals, group, reorder = FALSE)
-    if (aggregation == "mean") {
-      counts <- tabulate(match(group, as.integer(rownames(out))))
-      out <- out / counts
-    }
-    return(out)
+# Sum/mean aggregation as a single sparse-by-dense matrix product: a (n_doc x
+# n_vocab) document-token incidence matrix (sparse because each document holds
+# only a few of the vocabulary's tokens; the embedding matrix itself stays
+# dense) times the dense embedding matrix yields per-document sums directly, in
+# document order, without slicing or a grouped reduction.
+aggregate_embedding_linear <- function(
+  emb_mat,
+  doc_id,
+  token_index,
+  n_doc,
+  aggregation,
+  aggregation_default
+) {
+  incidence <- Matrix::sparseMatrix(
+    i = doc_id,
+    j = token_index,
+    x = 1,
+    dims = c(n_doc, nrow(emb_mat))
+  )
+  out <- as.matrix(incidence %*% emb_mat)
+  counts <- tabulate(doc_id, nbins = n_doc)
+  if (aggregation == "mean") {
+    out <- out / counts
   }
+  # Documents with no matched tokens get the default rather than a zero sum.
+  out[counts == 0L, ] <- aggregation_default
+  out
+}
 
+# Min/max aggregation of the rows of `vals` (a numeric matrix) by `group`,
+# returning a matrix with one row per present group and the group label as the
+# row name. Loops over the (relatively few) embedding columns, aggregating each
+# with a single vectorised `tapply`.
+aggregate_embedding_extremum <- function(vals, group, aggregation) {
   fun <- switch(aggregation, min = min, max = max)
   group <- factor(group)
-  # Loop over the (relatively few) embedding columns, aggregating each with a
-  # single vectorised `tapply`, rather than looping over the many groups.
   out <- vapply(
     seq_len(ncol(vals)),
     function(col) tapply(vals[, col], group, fun),

--- a/R/tokenlist.R
+++ b/R/tokenlist.R
@@ -306,22 +306,59 @@ tokenlist_ngram <- function(x, n, n_min, delim) {
   tokenlist(ngram(get_tokens(x), n, n_min, delim))
 }
 
-tokenlist_embedding <- function(x, emb, fun) {
+tokenlist_embedding <- function(x, emb, aggregation, aggregation_default) {
   tokens <- get_tokens(x)
-  seq_x <- seq_along(tokens)
-  i <- rep(seq_x, lengths(tokens))
-  unlisted_tokens <- unlist(tokens)
-  j <- match(unlisted_tokens, get_unique_tokens(x))
+  n_doc <- length(tokens)
+  emb_names <- names(emb)[-1]
+  n_dim <- length(emb_names)
 
-  keep_id <- !is.na(j)
-  split_id <- factor(i[keep_id], seq_x)
+  # Map each token occurrence to its document and its row in `emb`.
+  doc_id <- rep.int(seq_len(n_doc), lengths(tokens))
+  token_index <- match(unlist(tokens, use.names = FALSE), emb[[1]])
 
-  token_index <- match(unlisted_tokens, emb[[1]])
+  keep <- !is.na(token_index)
+  doc_id <- doc_id[keep]
+  token_index <- token_index[keep]
 
-  emb[token_index, -1] |>
-    dplyr::mutate("id" = split_id) |>
-    dplyr::filter(!is.na(token_index)) |>
-    dplyr::group_by(id, .drop = FALSE) |>
-    dplyr::summarise_all(fun, na.rm = TRUE) |>
-    dplyr::select(-"id")
+  res <- matrix(
+    aggregation_default,
+    nrow = n_doc,
+    ncol = n_dim,
+    dimnames = list(NULL, emb_names)
+  )
+
+  if (length(token_index) > 0L) {
+    emb_mat <- as.matrix(emb[, -1])
+    vals <- emb_mat[token_index, , drop = FALSE]
+
+    agg <- aggregate_embedding(vals, doc_id, aggregation)
+    res[as.integer(rownames(agg)), ] <- agg
+  }
+
+  tibble::as_tibble(res)
+}
+
+# Aggregate the rows of `vals` (a numeric matrix) by `group`, returning a matrix
+# with one row per present group and the group label as the row name.
+aggregate_embedding <- function(vals, group, aggregation) {
+  if (aggregation %in% c("sum", "mean")) {
+    out <- rowsum(vals, group, reorder = FALSE)
+    if (aggregation == "mean") {
+      counts <- tabulate(match(group, as.integer(rownames(out))))
+      out <- out / counts
+    }
+    return(out)
+  }
+
+  fun <- switch(aggregation, min = min, max = max)
+  group <- factor(group)
+  # Loop over the (relatively few) embedding columns, aggregating each with a
+  # single vectorised `tapply`, rather than looping over the many groups.
+  out <- vapply(
+    seq_len(ncol(vals)),
+    function(col) tapply(vals[, col], group, fun),
+    numeric(nlevels(group))
+  )
+  rownames(out) <- levels(group)
+  out
 }

--- a/R/word_embeddings.R
+++ b/R/word_embeddings.R
@@ -150,7 +150,9 @@ step_word_embeddings_new <- function(
   prefix,
   keep_original_cols,
   skip,
-  id
+  id,
+  emb_matrix = NULL,
+  emb_tokens = NULL
 ) {
   recipes::step(
     subclass = "word_embeddings",
@@ -164,7 +166,9 @@ step_word_embeddings_new <- function(
     prefix = prefix,
     keep_original_cols = keep_original_cols,
     skip = skip,
-    id = id
+    id = id,
+    emb_matrix = emb_matrix,
+    emb_tokens = emb_tokens
   )
 }
 
@@ -177,18 +181,25 @@ prep.step_word_embeddings <- function(x, training, info = NULL, ...) {
 
   check_type(training[, col_names], types = "tokenlist")
 
+  # Precompute the dense embedding matrix and its token lookup once here, rather
+  # than rebuilding them on every `bake()`.
+  emb_matrix <- as.matrix(x$embeddings[, -1])
+  emb_tokens <- x$embeddings[[1]]
+
   step_word_embeddings_new(
     terms = x$terms,
     role = x$role,
     trained = TRUE,
     columns = col_names,
-    embeddings = x$embeddings,
+    embeddings = NULL,
     aggregation = x$aggregation,
     aggregation_default = x$aggregation_default,
     prefix = x$prefix,
     keep_original_cols = get_keep_original_cols(x),
     skip = x$skip,
-    id = x$id
+    id = x$id,
+    emb_matrix = emb_matrix,
+    emb_tokens = emb_tokens
   )
 }
 
@@ -200,7 +211,8 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
   for (col_name in col_names) {
     emb_columns <- tokenlist_embedding(
       new_data[[col_name]],
-      object$embeddings,
+      object$emb_matrix,
+      object$emb_tokens,
       object$aggregation,
       object$aggregation_default
     )
@@ -245,7 +257,7 @@ tidy.step_word_embeddings <- function(x, ...) {
   if (is_trained(x)) {
     res <- tibble(
       terms = unname(x$columns %||% character()),
-      embeddings_rows = nrow(x$embeddings),
+      embeddings_rows = nrow(x$emb_matrix),
       aggregation = x$aggregation
     )
   } else {

--- a/R/word_embeddings.R
+++ b/R/word_embeddings.R
@@ -197,13 +197,12 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
   col_names <- object$columns
   check_new_data(col_names, object, new_data)
 
-  aggregation_fun <- get_aggregation_fun(object)
-
   for (col_name in col_names) {
     emb_columns <- tokenlist_embedding(
       new_data[[col_name]],
       object$embeddings,
-      aggregation_fun
+      object$aggregation,
+      object$aggregation_default
     )
 
     colnames(emb_columns) <- paste(
@@ -226,23 +225,6 @@ bake.step_word_embeddings <- function(object, new_data, ...) {
   new_data <- remove_original_cols(new_data, object, col_names)
 
   new_data
-}
-
-get_aggregation_fun <- function(object) {
-  fun <- switch(
-    EXPR = object$aggregation,
-    sum = sum,
-    mean = mean,
-    min = min,
-    max = max
-  )
-
-  function(x, ...) {
-    if (length(x) == 0) {
-      return(object$aggregation_default)
-    }
-    fun(x, ...)
-  }
 }
 
 #' @export

--- a/bench/ITERATIONS.md
+++ b/bench/ITERATIONS.md
@@ -1,0 +1,81 @@
+# Optimizing `step_word_embeddings`
+
+Goal: speed up the `bake()` path of `step_word_embeddings()`, which is driven by
+`tokenlist_embedding()` in `R/tokenlist.R`.
+
+Benchmark setup (`bench/bench_setup.R`): 50,000-token vocab, 100 embedding
+dimensions, 5,000 documents of 10-30 tokens each.
+
+## Baseline
+
+`tokenlist_embedding()` slices the embedding tibble by row, then runs a dplyr
+`group_by()` + `summarise_all()` pipeline:
+
+```r
+emb[token_index, -1] |>
+  dplyr::mutate("id" = split_id) |>
+  dplyr::filter(!is.na(token_index)) |>
+  dplyr::group_by(id, .drop = FALSE) |>
+  dplyr::summarise_all(fun, na.rm = TRUE) |>
+  dplyr::select(-"id")
+```
+
+Profiling (`bench/bench_setup.R`, default `sum` aggregation):
+
+- `bake()` elapsed: ~0.85 s
+- Self-time dominated by vctrs slicing (`ffi_slice`, `ffi_vec_chop`) of the
+  100-column tibble and dplyr group/summarise machinery, plus heavy GC.
+- Memory: ~140 MB allocated in `vec_slice` alone.
+
+Root causes:
+1. Slicing a 100-column **tibble** by row is far slower than slicing a matrix.
+2. The dplyr group/summarise pipeline has high per-call overhead and allocates a
+   lot.
+
+## Iteration 1: matrix + `rowsum` instead of the dplyr pipeline
+
+Rewrote `tokenlist_embedding()` to:
+
+- Convert the embedding tibble to a numeric **matrix** once and slice rows from
+  it (matrix row-slicing is far cheaper than tibble slicing).
+- Pass the `aggregation` name and `aggregation_default` through instead of an
+  opaque closure, so the aggregation can be vectorised.
+- Aggregate `sum`/`mean` with base `rowsum()` (a single C call), dividing by
+  group counts for `mean`. `min`/`max` initially aggregated with a per-group
+  `apply()`.
+
+`get_aggregation_fun()` was removed (no longer needed).
+
+Results (per-run `bake`, 3 runs):
+
+| aggregation | before | after |
+|-------------|--------|-------|
+| sum         | 0.85 s | 0.066 s (~13x) |
+| mean        | 0.85 s | 0.067 s (~13x) |
+| min         | 0.85 s | 0.378 s (~2.2x) |
+| max         | 0.85 s | 0.379 s (~2.2x) |
+
+Output verified identical to the documented example for all four aggregations.
+`min`/`max` lagged because the per-group `apply()` loops over thousands of
+documents.
+
+## Iteration 2: vectorise `min`/`max` over columns
+
+Replaced the per-group `apply()` with a loop over the ~100 embedding columns,
+each aggregated by a single `tapply()`. Far fewer iterations (columns, not
+documents).
+
+| aggregation | iter 1 | iter 2 |
+|-------------|--------|--------|
+| min         | 0.378 s | 0.360 s |
+| max         | 0.379 s | 0.338 s |
+
+Modest further gain. `min`/`max` remain bounded by `tapply`'s internal grouping;
+the default `sum`/`mean` path (the common case) is the headline ~13x win.
+
+## Notes
+
+- The full `devtools::test()` run segfaults inside an unrelated `ngram` C-code
+  test under `load_all`; this reproduces on a clean tree (pre-existing, not
+  caused by these changes). The `word_embeddings` tests pass (40 PASS).
+

--- a/bench/ITERATIONS.md
+++ b/bench/ITERATIONS.md
@@ -73,6 +73,50 @@ documents).
 Modest further gain. `min`/`max` remain bounded by `tapply`'s internal grouping;
 the default `sum`/`mean` path (the common case) is the headline ~13x win.
 
+## Iteration 3: sparse incidence matrix product for sum/mean
+
+Re-profiling the `sum` path showed `rowsum.default` (~39% self-time) and the
+`emb_mat[token_index, ]` row-slice (~14%) as the new hot spots, with heavy GC
+(~22%) from the 80k x 100 slice allocation each bake.
+
+Replaced slice + `rowsum` with a single **sparse-by-dense matrix product**:
+
+```r
+incidence <- Matrix::sparseMatrix(i = doc_id, j = token_index, x = 1,
+                                  dims = c(n_doc, nrow(emb_mat)))
+out <- as.matrix(incidence %*% emb_mat)            # per-document sums, in order
+if (aggregation == "mean") out <- out / counts
+out[counts == 0, ] <- aggregation_default          # empty docs get the default
+```
+
+The **embedding matrix stays dense**; only the document-token incidence matrix
+is sparse, and it is sparse by construction (each document contains only a few
+of the vocabulary's tokens) no matter what the embedding values are. The product
+lands directly in document order, so it needs no row-slice, no grouped
+reduction, and no remapping of group labels back to rows. `min`/`max` keep the
+column-wise `tapply` path. `Matrix` is already a package dependency.
+
+| aggregation | iter 2 | iter 3 |
+|-------------|--------|--------|
+| sum         | 0.066 s | 0.045 s |
+| mean        | 0.067 s | 0.038 s |
+| min         | 0.360 s | 0.342 s |
+| max         | 0.338 s | 0.336 s |
+
+After this change the remaining `bake` time is dominated by `step_tokenize`
+(`stri_split_boundaries`, `stri_trans_tolower`) and the intrinsic `%*%`
+multiply-add work, i.e. there is little left to win inside
+`step_word_embeddings` itself for the default aggregations.
+
+## Cumulative result
+
+| aggregation | baseline | final | speedup |
+|-------------|----------|-------|---------|
+| sum         | 0.85 s | 0.045 s | ~19x |
+| mean        | 0.85 s | 0.038 s | ~22x |
+| min         | 0.85 s | 0.342 s | ~2.5x |
+| max         | 0.85 s | 0.336 s | ~2.5x |
+
 ## Notes
 
 - The full `devtools::test()` run segfaults inside an unrelated `ngram` C-code

--- a/bench/ITERATIONS.md
+++ b/bench/ITERATIONS.md
@@ -108,14 +108,44 @@ After this change the remaining `bake` time is dominated by `step_tokenize`
 multiply-add work, i.e. there is little left to win inside
 `step_word_embeddings` itself for the default aggregations.
 
+## Iteration 4: precompute the dense embedding matrix in `prep()`
+
+Profiling iteration 3 showed `as.matrix(emb[, -1])` ran on every `bake()`,
+costing ~22% of the step's own time and (more importantly) allocating the whole
+~40 MB embedding matrix each call, which drove a lot of the GC.
+
+Moved the conversion into `prep()`: the prepped step now stores a dense
+`emb_matrix` plus an `emb_tokens` lookup vector instead of the embeddings tibble
+(no memory duplication: an all-numeric matrix is no larger than the tibble it
+replaces). `bake()`/`tokenlist_embedding()` take the matrix and tokens directly,
+and `tidy()` reads the row count from `emb_matrix`.
+
+| aggregation | iter 3 | iter 4 |
+|-------------|--------|--------|
+| sum         | 0.045 s | 0.027 s |
+| mean        | 0.038 s | 0.027 s |
+| min         | 0.342 s | 0.325 s |
+| max         | 0.336 s | 0.301 s |
+
+The win exceeds the bare `as.matrix` time because dropping the 40 MB
+per-`bake()` allocation also cuts GC.
+
+### Rejected within this iteration
+
+For `min`/`max` I also tried two replacements for the column-wise `tapply`: a
+single flattened `tapply` over all columns at once (~2x *slower*), and an
+`order()` + `duplicated(fromLast=)` pick per column (~12% faster). The latter's
+gain was too small for the added complexity on a non-default path, so it was
+rejected.
+
 ## Cumulative result
 
 | aggregation | baseline | final | speedup |
 |-------------|----------|-------|---------|
-| sum         | 0.85 s | 0.045 s | ~19x |
-| mean        | 0.85 s | 0.038 s | ~22x |
-| min         | 0.85 s | 0.342 s | ~2.5x |
-| max         | 0.85 s | 0.336 s | ~2.5x |
+| sum         | 0.85 s | 0.027 s | ~31x |
+| mean        | 0.85 s | 0.027 s | ~31x |
+| min         | 0.85 s | 0.325 s | ~2.6x |
+| max         | 0.85 s | 0.301 s | ~2.8x |
 
 ## Notes
 

--- a/bench/bench_setup.R
+++ b/bench/bench_setup.R
@@ -1,0 +1,29 @@
+library(recipes)
+library(textrecipes)
+library(tibble)
+
+set.seed(123)
+
+# Large embedding matrix: 50k vocab, 100 dims
+n_vocab <- 50000
+n_dim <- 100
+vocab <- paste0("word", seq_len(n_vocab))
+emb_mat <- matrix(rnorm(n_vocab * n_dim), nrow = n_vocab)
+embeddings <- tibble::as_tibble(emb_mat, .name_repair = "minimal")
+names(embeddings) <- paste0("d", seq_len(n_dim))
+embeddings <- tibble::add_column(embeddings, tokens = vocab, .before = 1)
+
+# Sample data: 5000 documents, ~20 tokens each drawn from vocab
+n_doc <- 5000
+make_doc <- function() {
+  k <- sample(10:30, 1)
+  paste(sample(vocab, k, replace = TRUE), collapse = " ")
+}
+sample_data <- tibble(
+  text = vapply(seq_len(n_doc), function(i) make_doc(), character(1)),
+  text_label = sample(c("a", "b"), n_doc, replace = TRUE)
+)
+
+rec <- recipe(text_label ~ ., data = sample_data) |>
+  step_tokenize(text) |>
+  step_word_embeddings(text, embeddings = embeddings)


### PR DESCRIPTION
> [!NOTE]
> This PR is a showcase of using [{debrief}](https://github.com/jcheng5/debrief) to drive a profiling-based optimization. Each iteration below came from profiling with `profvis` + `debrief`.
## Origin

This started from the following prompt:

> look the following code
>
> ```r
> library(recipes)
> library(textrecipes)
>
> embeddings <- tibble(
>   tokens = c("the", "cat", "ran"),
>   d1 = c(1, 0, 0),
>   d2 = c(0, 1, 0),
>   d3 = c(0, 0, 1)
> )
>
> sample_data <- tibble(
>   text = c(
>     "The.",
>     "The cat.",
>     "The cat ran."
>   ),
>   text_label = c("fragment", "fragment", "sentence")
> )
>
> rec <- recipe(text_label ~ ., data = sample_data) |>
>   step_tokenize(text) |>
>   step_word_embeddings(text, embeddings = embeddings)
>
> rec |> prep() |> bake(sample_data)
> ```
>
> I want to See if there are room for improvements. specifically in the step_word_embeddings part.
>
> Use the debrief package like so:
>
> ```r
> library(profvis)
> library(debrief)
>
> # Profile some code
> p <- profvis({
>   # your code here
> })
>
> # Get help on available functions
> pv_help()
>
> # Start with a summary
> pv_print_debrief(p)
> ```
>
> you will need to profile this line
>
> ```r
> rec |> prep() |> bake(sample_data)
> ```
>
> This is a iterative process. In a document write down each itteration that you take. Do a commit for each accepted change. you might need to generate new data for embeddings and sample_data to properly test the speed as this data set is quite small

## Summary

Speeds up the `bake()` path of `step_word_embeddings()`, which was driven by `tokenlist_embedding()` in `R/tokenlist.R`. The original implementation sliced the embedding tibble by row and ran a dplyr `group_by()` + `summarise_all()` pipeline per document. This was rewritten over several profiling-driven iterations into matrix/sparse-matrix operations.

On a benchmark of 5,000 documents (10-30 tokens each), a 50,000-token vocabulary, and 100 embedding dimensions:

| aggregation | baseline | this PR | speedup |
|-------------|----------|---------|---------|
| sum         | 0.85 s   | 0.027 s | ~31x |
| mean        | 0.85 s   | 0.027 s | ~31x |
| min         | 0.85 s   | 0.325 s | ~2.6x |
| max         | 0.85 s   | 0.301 s | ~2.8x |

Output is identical to before for all four aggregations, including documents with no matched tokens falling back to `aggregation_default`. All `word_embeddings` tests pass.

## Iterations

The work was done as a sequence of profile-measure-change steps (full notes and benchmark script live in `bench/`, which is `.Rbuildignore`d).

**Baseline.** Profiling showed nearly all the cost in `tokenlist_embedding()`: slicing a 100-column **tibble** by row (`vec_slice`, ~140 MB allocated) and the dplyr group/summarise machinery, plus heavy GC.

**Iteration 1: matrix + `rowsum`.** Convert the embeddings to a numeric matrix and slice rows from it (matrix slicing is far cheaper than tibble slicing), pass the aggregation name through instead of an opaque closure, and aggregate `sum`/`mean` with base `rowsum()`. → sum/mean ~13x; min/max ~2.2x (still using a per-group `apply()`).

**Iteration 2: vectorise min/max.** Replace the per-group `apply()` with a loop over the ~100 embedding columns, each aggregated by a single `tapply()` (far fewer iterations). → modest further gain on min/max.

**Iteration 3: sparse incidence product for sum/mean.** Re-profiling showed `rowsum.default` and the row-slice as the new hot spots. Replaced them with a single sparse-by-dense matrix product: a (n_doc x n_vocab) document-token incidence matrix times the dense embedding matrix yields per-document sums directly, in document order, with no row-slice and no grouped reduction. The **embedding matrix stays dense** here; only the incidence matrix is sparse, and it is sparse by construction (each document holds only a few of the vocabulary's tokens) regardless of the embedding values. `Matrix` is already a dependency. → sum/mean ~19-22x.

**Iteration 4: precompute the dense matrix in `prep()`.** `as.matrix()` was running on every `bake()`, allocating the whole ~40 MB embedding matrix each call and driving much of the GC. Moved the conversion into `prep()`: the prepped step now stores a dense `emb_matrix` plus an `emb_tokens` lookup vector instead of the embeddings tibble (no memory duplication, since an all-numeric matrix is no larger than the tibble), and `tidy()` reads the row count from `emb_matrix`. → sum/mean roughly halved again, ~31x overall.

### Rejected experiments

For min/max I also tried a single flattened `tapply` over all columns at once (~2x *slower*) and an `order()` + `duplicated(fromLast=)` pick per column (~12% faster). The latter's gain was too small for the added complexity on a non-default path, so it was not kept.

## Notes

- The default `sum`/`mean` path is now down to tokenization plus the intrinsic matrix multiply; there is little structural overhead left to remove.
- The full `devtools::test()` run segfaults inside an unrelated `ngram` C-code test under `load_all`; this reproduces on a clean `main` tree (pre-existing, not caused by this PR). The `word_embeddings` tests pass (40 PASS).

