### PR TITLE
Add R4.6 snapshot variants for BPE tests

### DIFF
--- a/tests/testthat/_snaps/R4.2/tokenize_bpe.md
+++ b/tests/testthat/_snaps/R4.2/tokenize_bpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      prep(step_tokenize_bpe(recipe(~text1, data = test_data), text1,
+      vocabulary_size = 10))
+    Condition
+      Error in `step_tokenize_bpe()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 10 is too small for column `text1` which has a unique character count of 23
+

--- a/tests/testthat/_snaps/R4.2/tokenizer-tokenizersbpe.md
+++ b/tests/testthat/_snaps/R4.2/tokenizer-tokenizersbpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      prep(step_tokenize(recipe(~text, data = tibble(text = "hello")), text, engine = "tokenizers.bpe",
+      training_options = list(vocab_size = 2)))
+    Condition
+      Error in `step_tokenize()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 2 is too small for column `text` which has a unique character count of 4
+

--- a/tests/testthat/_snaps/R4.6/tokenize_bpe.md
+++ b/tests/testthat/_snaps/R4.6/tokenize_bpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      prep(step_tokenize_bpe(recipe(~text1, data = test_data), text1,
+      vocabulary_size = 10))
+    Condition
+      Error in `step_tokenize_bpe()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 10 is too small for column `text1` which has a unique character count of 23
+

--- a/tests/testthat/_snaps/R4.6/tokenizer-tokenizersbpe.md
+++ b/tests/testthat/_snaps/R4.6/tokenizer-tokenizersbpe.md
@@ -1,0 +1,10 @@
+# Errors if vocabulary size is set to low.
+
+    Code
+      prep(step_tokenize(recipe(~text, data = tibble(text = "hello")), text, engine = "tokenizers.bpe",
+      training_options = list(vocab_size = 2)))
+    Condition
+      Error in `step_tokenize()`:
+      Caused by error in `prep()`:
+      ! `vocabulary_size` of 2 is too small for column `text` which has a unique character count of 4
+


### PR DESCRIPTION
## Problem

The GHA checks on #309 (and any current PR) fail on Windows R CMD check with two test failures, unrelated to that PR's `step_word_embeddings()` work:

```
── Failure ('test-tokenize_bpe.R:169:3'): Errors if vocabulary size is set to low. ──
Adding new snapshot for variant 'R4.6'
── Failure ('test-tokenizer-tokenizersbpe.R:198:3'): Errors if vocabulary size is set to low. ──
Adding new snapshot for variant 'R4.6'
```

## Cause

Both tests use `expect_snapshot(variant = r_version())`, where `r_version()` is `paste0("R", getRversion()[, 1:2])`. The CI runners were bumped to **R 4.6.0**, so `r_version()` now returns `"R4.6"`. There were variant snapshot directories for `R4.3`, `R4.4`, and `R4.5` but none for `R4.6`, so testthat treats it as a brand-new snapshot, which is a failure under CI.

## Fix

The expected error messages here are generated by textrecipes itself and are byte-identical across R 4.3-4.5, so this adds an `R4.6` variant directory copied from the existing `R4.5` snapshots.

(The macOS R-CMD-check failure on #309 is separate: `recipes` failed to `dyn.load` on the R 4.6.0 arm64 runner, a transient upstream binary issue not addressed here.)